### PR TITLE
improve packagingand add.deb Makefile target

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,7 @@ steps:
           skip_verify: true
 
     - name: dependencies
-      image: golang:1.12.5-stretch
+      image: golang:1.13.4-stretch
       pull: always
       environment:
           GO111MODULE: on
@@ -33,16 +33,13 @@ steps:
               - push
 
     - name: build
-      image: golang:1.12.5-stretch
+      image: golang:1.13.4-stretch
       pull: always
       environment:
           GO111MODULE: on
       commands:
-          - cd pkg/version
-          - export COMMIT_SHA=$(git rev-parse HEAD)
-          - go generate
-          - cd ../../
-          - go install ./...
+          - cd addon
+          - make all
           - goQuery -version
       when:
           branch:
@@ -53,7 +50,7 @@ steps:
               - push
 
     - name: test
-      image: golang:1.12.5-stretch
+      image: golang:1.13.4-stretch
       pull: always
       environment:
           GO111MODULE: on
@@ -69,7 +66,7 @@ steps:
               - push
 
     - name: vet
-      image: golang:1.12.5-stretch
+      image: golang:1.13.4-stretch
       pull: always
       environment:
           GO111MODULE: on
@@ -85,18 +82,16 @@ steps:
               - push
 
     - name: merge
-      image: golang:1.12.5-stretch
+      image: golang:1.13.4-stretch
       pull: always
       environment:
           GO111MODULE: on
           GODB_LOGGER: console
       commands:
           - go get ./...
-          - cd pkg/version
-          - export COMMIT_SHA=$(git rev-parse HEAD)
-          - go generate
-          - cd ../../
-          - go install ./...
+          - cd addon
+          - make all
+          - go test
           - go test -v ./...
           - golint ./... | grep -Ev "(annoying|MixedCaps|ColIdx)"
       when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -40,7 +40,7 @@ steps:
       commands:
           - cd addon
           - make all
-          - goQuery -version
+          - absolute/bin/goQuery -version
       when:
           branch:
               - master

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+*.bz2
+*.deb
 absolute
+cmd/goProbe/goProbe
+cmd/goQuery/goQuery
+cmd/goConvert/goConvert

--- a/CHANGES
+++ b/CHANGES
@@ -56,3 +56,4 @@ UNRELEASED fako1024,els0r
     - start fetching fako's gopacket via go get
     - get rid of fetching golang, effectively making a go installation a pre-requisite
     - remove all mentions of libpcap from the repository
+    - improve packaging and add .deb Makefile target

--- a/CHANGES
+++ b/CHANGES
@@ -57,3 +57,4 @@ UNRELEASED fako1024,els0r
     - get rid of fetching golang, effectively making a go installation a pre-requisite
     - remove all mentions of libpcap from the repository
     - improve packaging and add .deb Makefile target
+    - Add explicit systemd timeout for stop target to ensure that a stalling goprobe is killed

--- a/README.md
+++ b/README.md
@@ -72,20 +72,20 @@ The flow data is written out to a custom colum store called `goDB`, which was sp
 Capturing is performed concurrently by goProbe on multiple interfaces. goProbe is started as follows (either as `root` or as non-root with capability `CAP_NET_RAW`):
 
 ```
-/opt/ntm/goProbe/bin/goProbe -config <path to configuration file>
+/usr/local/goProbe/bin/goProbe -config <path to configuration file>
 ```
 The capturing probe can be run as a daemon via
 
 ```
-/etc/init.d/goprobe.init {start|stop|status|restart|reload|force-reload}
+systemctl {start|stop|status|restart|reload|force-reload} goprobe.service
 ```
 
 ### Configuration
 
 You must configure goProbe. By default, the relevant configuration file resides in
-`/opt/ntm/goProbe/etc/goprobe.conf`. The config covers three aspects of goProbe: capturing, logging and the API.
+`/etc/goprobe.conf`. The config covers three aspects of goProbe: capturing, logging and the API.
 
-An example configuration file is created during installation at `/opt/ntm/goProbe/etc/goprobe.conf.example`.
+An example configuration file is created during installation at `/etc/goprobe.conf.example`.
 
 #### DB location
 
@@ -182,7 +182,7 @@ goQuery
 
 ### Usage
 
-For a comprehensive help on how to use goQuery type `/opt/ntm/goProbe/bin/goQuery -h` or `/opt/ntm/goProbe/bin/goQuery help`.
+For a comprehensive help on how to use goQuery type `/bin/goQuery -h` or `/bin/goQuery help`.
 
 ### Example Output
 
@@ -272,8 +272,6 @@ The args file can look as follows:
 Installation
 ------------
 
-*Note*: the default directory for `goProbe` is `/opt/ntm/goProbe`. If you wish to change this, change the `PREFIX` variable in the `Makefile` to a destination of your choosing.
-
 Before running the installer, make sure that you have the following dependencies installed:
 * golang
 * socat (for init script usage only)
@@ -315,8 +313,8 @@ _goquery() {
         ;;
 
         *)
-            if [ -x /opt/ntm/goProbe/shared/goquery_completion ]; then
-                mapfile -t COMPREPLY < <( /opt/ntm/goProbe/shared/goquery_completion bash "${COMP_POINT}" "${COMP_LINE}" )
+            if [ -x /usr/local/share/goquery_completion ]; then
+                mapfile -t COMPREPLY < <( /usr/local/share/goquery_completion bash "${COMP_POINT}" "${COMP_LINE}" )
             fi
         ;;
     esac

--- a/addon/Makefile
+++ b/addon/Makefile
@@ -41,7 +41,7 @@ GO_QUERY	= goQuery
 
 # get the operating system and git variables for versioning
 UNAME_OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
-GIT_COMMIT := $(shell git rev-parse HEAD)
+COMMIT_SHA := $(shell git rev-parse HEAD)
 GIT_VERSION := $(shell git describe --tags)
 DEB_VERSION := $(shell echo $(GIT_VERSION) | sed 's/v//g')
 BUILD_DATE  := $(shell date +%FT%T%z)
@@ -50,8 +50,7 @@ BUILD_DATE  := $(shell date +%FT%T%z)
 VERSION_PATH = $(BASEPATH)/pkg/version
 
 GO_BUILDTAGS = netcgo public $(UNAME_OS)
-GO_LDFLAGS   = -ldflags '-X $(VERSION_PATH).version=$(GIT_VERSION) -X $(VERSION_PATH).commit=$(GIT_COMMIT) -X $(VERSION_PATH).builddate=$(BUILD_DATE)'
-GPBUILD      = go install -i -tags '$(GO_BUILDTAGS)' $(GO_LDFLAGS)
+GPBUILD      = go install -i -tags '$(GO_BUILDTAGS)'
 GPTESTBUILD  = go test -c -tags '$(GO_BUILDTAGS)'
 
 # gopacket and gopcap
@@ -65,6 +64,10 @@ fetch:
 	go get github.com/els0r/status
 
 compile:
+
+	## VERSION ###
+	echo "*** setting version information ***"
+	COMMIT_SHA=$(COMMIT_SHA) go generate $(BASEPATH)/pkg/version
 
 	## GO CODE COMPILATION ##
 	echo "*** compiling $(GO_PRODUCT) ***"

--- a/addon/Makefile
+++ b/addon/Makefile
@@ -98,12 +98,11 @@ go_install:
 	echo "*** generating example configuration ***"
 	echo -e "{\n\t\"db_path\" : \"/usr/local/$(GO_PRODUCT)/db\",\n\t\"interfaces\" : {\n\t\t\"eth0\" : {\n\t\t\t\"bpf_filter\" : \"not arp and not icmp\",\n\t\t\t\"buf_size\" : 2097152,\n\t\t\t\"promisc\" : false\n\t\t}\n\t}\n}" > absolute/etc/goprobe.conf.example
 
-	#set the appropriate permissions
-	chmod -R 755 absolute/bin \
-		absolute/etc \
+	#set the appropriate permissions for files
+	chmod -R 755 absolute/bin
+	chown root.root absolute/etc/systemd/system/goprobe.service
 
 	echo "*** cleaning unneeded files ***"
-
 	# strip binaries
 	if [ "$(UNAME_OS)" != "darwin" ]; \
 	then \
@@ -133,7 +132,6 @@ deploy:
 	else \
 		echo "*** syncing binary tree ***"; \
 		rsync -a absolute/ /; \
-		chown root.root /etc/systemd/system/goprobe.service; \
 		systemctl daemon-reload
 	fi
 

--- a/addon/Makefile
+++ b/addon/Makefile
@@ -34,18 +34,16 @@
 # public code is used.
 SHELL := /bin/bash
 
-PKG    = goProbe
-PREFIX = /opt/ntm
-
 # GoLang main version
-BASEPATH		= github.com/els0r/goProbe
-GO_PRODUCT	    = goProbe
-GO_QUERY        = goQuery
+BASEPATH	= github.com/els0r/goProbe
+GO_PRODUCT	= goProbe
+GO_QUERY	= goQuery
 
 # get the operating system and git variables for versioning
 UNAME_OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 GIT_COMMIT := $(shell git rev-parse HEAD)
 GIT_VERSION := $(shell git describe --tags)
+DEB_VERSION := $(shell echo $(GIT_VERSION) | sed 's/v//g')
 BUILD_DATE  := $(shell date +%FT%T%z)
 
 # easy to use build command for everything related goprobe
@@ -86,40 +84,46 @@ go_install:
 
 	# additional directories
 	echo "*** creating binary tree ***"
-	mkdir -p absolute$(PREFIX)/$(PKG)/bin    && chmod 755 absolute$(PREFIX)/$(PKG)/bin
-	mkdir -p absolute$(PREFIX)/$(PKG)/etc    && chmod 755 absolute$(PREFIX)/$(PKG)/etc
-	mkdir -p absolute/etc/init.d             && chmod 755 absolute/etc/init.d
+	mkdir -p absolute/bin                    && chmod 755 absolute/bin
+	mkdir -p absolute/etc/systemd/system     && chmod 755 absolute/etc/systemd/system
 
 	echo "*** installing $(GO_PRODUCT) and $(GO_QUERY) ***"
-	mv $(GOPATH)/bin/goProbe 	absolute$(PREFIX)/$(PKG)/bin
-	mv $(GOPATH)/bin/goQuery   	absolute$(PREFIX)/$(PKG)/bin
-	mv $(GOPATH)/bin/goConvert  absolute$(PREFIX)/$(PKG)/bin
+	mv $(GOPATH)/bin/goProbe 	absolute/bin
+	mv $(GOPATH)/bin/goQuery   	absolute/bin
+	mv $(GOPATH)/bin/goConvert      absolute/bin
 
-	# change the prefix variable in the init script
-	cp goprobe.init absolute/etc/init.d/goprobe.init
-	sed "s#PREFIX=#PREFIX=$(PREFIX)#g" -i absolute/etc/init.d/goprobe.init
+	# systemd service definition
+	cp goprobe.service absolute/etc/systemd/system/goprobe.service
 
 	echo "*** generating example configuration ***"
-	echo -e "{\n\t\"db_path\" : \"$(PREFIX)/$(PKG)/db\",\n\t\"interfaces\" : {\n\t\t\"eth0\" : {\n\t\t\t\"bpf_filter\" : \"not arp and not icmp\",\n\t\t\t\"buf_size\" : 2097152,\n\t\t\t\"promisc\" : false\n\t\t}\n\t}\n}" > absolute$(PREFIX)/$(PKG)/etc/goprobe.conf.example
+	echo -e "{\n\t\"db_path\" : \"/usr/local/$(GO_PRODUCT)/db\",\n\t\"interfaces\" : {\n\t\t\"eth0\" : {\n\t\t\t\"bpf_filter\" : \"not arp and not icmp\",\n\t\t\t\"buf_size\" : 2097152,\n\t\t\t\"promisc\" : false\n\t\t}\n\t}\n}" > absolute/etc/goprobe.conf.example
 
 	#set the appropriate permissions
-	chmod -R 755 absolute$(PREFIX)/$(PKG)/bin \
-		absolute$(PREFIX)/$(PKG)/etc \
-		absolute/etc/init.d \
+	chmod -R 755 absolute/bin \
+		absolute/etc \
 
 	echo "*** cleaning unneeded files ***"
 
 	# strip binaries
 	if [ "$(UNAME_OS)" != "darwin" ]; \
 	then \
-		strip --strip-unneeded absolute$(PREFIX)/$(PKG)/bin/*; \
+		strip --strip-unneeded absolute/bin/*; \
 	fi
 
 package: go_package
 
 go_package:
 
-	cd absolute; tar cjf $(PKG).tar.bz2 *; mv $(PKG).tar.bz2 ../
+	cd absolute; tar cjf $(GO_PRODUCT).tar.bz2 *; mv $(GO_PRODUCT).tar.bz2 ../
+
+deb:
+
+	mkdir -p $(DEB_VERSION)/DEBIAN
+	sed 's/{{VERSION}}/$(DEB_VERSION)/g' deb-control > $(DEB_VERSION)/DEBIAN/control
+	cp preinst postrm postinst $(DEB_VERSION)/DEBIAN/
+	cp -r absolute/* $(DEB_VERSION)/
+	docker run --rm -v $(PWD)/$(DEB_VERSION):/$(DEB_VERSION) -v $(PWD):/output debian:buster-slim dpkg-deb --build $(DEB_VERSION) /output/$(GO_PRODUCT)-$(DEB_VERSION).deb
+	rm -rf $(DEB_VERSION)
 
 deploy:
 
@@ -129,8 +133,8 @@ deploy:
 	else \
 		echo "*** syncing binary tree ***"; \
 		rsync -a absolute/ /; \
-		ln -sf $(PREFIX)/$(PKG)/bin/goQuery /usr/local/bin/goquery; \
-		chown root.root /etc/init.d/goprobe.init; \
+		chown root.root /etc/systemd/system/goprobe.service; \
+		systemctl daemon-reload
 	fi
 
 clean:
@@ -141,7 +145,8 @@ clean:
 	echo "*** removing dependencies and binaries ***"
 	rm -rf cmd/$(GO_PRODUCT)/$(GO_PRODUCT) cmd/$(GO_QUERY)/$(GO_QUERY) cmd/goConvert/goConvert
 
-	rm -rf $(PKG).tar.bz2
+	rm -f $(GO_PRODUCT).tar.bz2
+	rm -f $(GO_PRODUCT)-$(DEB_VERSION).deb
 
 all: clean fetch compile install
 

--- a/addon/Makefile
+++ b/addon/Makefile
@@ -100,7 +100,6 @@ go_install:
 
 	#set the appropriate permissions for files
 	chmod -R 755 absolute/bin
-	chown root.root absolute/etc/systemd/system/goprobe.service
 
 	echo "*** cleaning unneeded files ***"
 	# strip binaries
@@ -121,7 +120,9 @@ deb:
 	sed 's/{{VERSION}}/$(DEB_VERSION)/g' deb-control > $(DEB_VERSION)/DEBIAN/control
 	cp preinst postrm postinst $(DEB_VERSION)/DEBIAN/
 	cp -r absolute/* $(DEB_VERSION)/
+	docker run --rm -v $(PWD)/$(DEB_VERSION):/$(DEB_VERSION) debian:buster-slim chown -R root.root $(DEB_VERSION)/{bin,etc}
 	docker run --rm -v $(PWD)/$(DEB_VERSION):/$(DEB_VERSION) -v $(PWD):/output debian:buster-slim dpkg-deb --build $(DEB_VERSION) /output/$(GO_PRODUCT)-$(DEB_VERSION).deb
+	docker run --rm -v $(PWD)/$(DEB_VERSION):/$(DEB_VERSION) debian:buster-slim rm -rf $(DEB_VERSION)/{bin,etc}
 	rm -rf $(DEB_VERSION)
 
 deploy:
@@ -132,6 +133,7 @@ deploy:
 	else \
 		echo "*** syncing binary tree ***"; \
 		rsync -a absolute/ /; \
+		chown root.root /etc/systemd/system/goprobe.service; \
 		systemctl daemon-reload
 	fi
 

--- a/addon/deb-control
+++ b/addon/deb-control
@@ -1,0 +1,7 @@
+Package: goprobe
+Version: {{VERSION}}
+Section: base
+Priority: optional
+Architecture: amd64
+Maintainer: fako1024
+Description: Network Traffic Monitoring

--- a/addon/goprobe.service
+++ b/addon/goprobe.service
@@ -1,11 +1,13 @@
 [Unit]
 Description=Network Traffic Monitoring
-After=network.target syslog.target
+After=network-online.target syslog.target
 
 [Service]
-ExecStart=/bin/goProbe -config /opt/ntm/goProbe/etc/goprobe.conf
+Type=simple
+ExecStart=/bin/goProbe -config /etc/goprobe.conf
 StandardOutput=syslog
 Restart=on-failure
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/addon/goprobe.service
+++ b/addon/goprobe.service
@@ -8,6 +8,7 @@ ExecStart=/bin/goProbe -config /etc/goprobe.conf
 StandardOutput=syslog
 Restart=on-failure
 RestartSec=10
+TimeoutStopSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/addon/goprobe.targets
+++ b/addon/goprobe.targets
@@ -2,13 +2,13 @@
 
 case $1 in
   reload)
-    /bin/echo "RELOAD" | /usr/bin/socat - UNIX-CONNECT:PREFIX/goProbe/db/control.sock > /dev/null
+    /bin/echo "RELOAD" | /usr/bin/socat - UNIX-CONNECT:/usr/local/goProbe/db/control.sock > /dev/null
     ;;
   status)
-    /bin/echo "STATUS" | /usr/bin/socat - UNIX-CONNECT:/opt/ntm/goProbe/db/control.sock
+    /bin/echo "STATUS" | /usr/bin/socat - UNIX-CONNECT:/usr/local/goProbe/db/control.sock
     ;;
   debug)
-    /bin/echo "STATUS" | /usr/bin/socat - UNIX-CONNECT:/opt/ntm/goProbe/db/control.sock
+    /bin/echo "STATUS" | /usr/bin/socat - UNIX-CONNECT:/usr/local/goProbe/db/control.sock
     ;;
   *)
     ;;

--- a/addon/postinst
+++ b/addon/postinst
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+systemctl daemon-reload

--- a/addon/postrm
+++ b/addon/postrm
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+systemctl daemon-reload

--- a/addon/preinst
+++ b/addon/preinst
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mkdir -p /usr/local/goProbe

--- a/cmd/goProbe/config/config_test.go
+++ b/cmd/goProbe/config/config_test.go
@@ -13,47 +13,47 @@ var tests = []struct {
 	{
 		"wrong discovery config",
 		true,
-		`{ "db_path" : "/opt/ntm/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false, "service_discovery" : { "registry": "192.168.1.1:5000" } } }`,
+		`{ "db_path" : "/usr/local/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false, "service_discovery" : { "registry": "192.168.1.1:5000" } } }`,
 	},
 	{
 		"valid configuration (api, logging, discovery)",
 		false,
-		`{ "db_path" : "/opt/ntm/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false, "service_discovery" : { "endpoint" : "localhost:6060", "registry": "192.168.1.1:5000", "probe_identifier": "test_probe" } } }`,
+		`{ "db_path" : "/usr/local/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false, "service_discovery" : { "endpoint" : "localhost:6060", "registry": "192.168.1.1:5000", "probe_identifier": "test_probe" } } }`,
 	},
 	{
 		"valid configuration (api, logging)",
 		false,
-		`{ "db_path" : "/opt/ntm/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false } }`,
+		`{ "db_path" : "/usr/local/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false } }`,
 	},
 	{
 		"fails on API section",
 		true,
 		// should fail on API section
-		`{ "db_path" : "/opt/ntm/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true }, "en1" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : true, "keys" : [ "da53ae3fb482db63d9606a9324a694bf51f7ad47623c04ab7b97a811f2a78e05", "9e3b84ae1437a73154ac5c48a37d5085a3f6e68621b56b626f81620de271a2f6" ] } }`,
+		`{ "db_path" : "/usr/local/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true }, "en1" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : true, "keys" : [ "da53ae3fb482db63d9606a9324a694bf51f7ad47623c04ab7b97a811f2a78e05", "9e3b84ae1437a73154ac5c48a37d5085a3f6e68621b56b626f81620de271a2f6" ] } }`,
 	},
 	{
 		"missing iface config",
 		true,
 		// fails due to missing iface config
-		`{ "db_path" : "/opt/ntm/goProbe/db", "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false } }`,
+		`{ "db_path" : "/usr/local/goProbe/db", "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false } }`,
 	},
 	{
 		"missing API port",
 		true,
 		// fails due to empty API port
-		`{ "db_path" : "/opt/ntm/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "", "request_logging" : false } }`,
+		`{ "db_path" : "/usr/local/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "", "request_logging" : false } }`,
 	},
 	{
 		"insecure API key",
 		true,
 		// fails due to insecure API key
-		`{ "db_path" : "/opt/ntm/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false, "keys" : [ "i am too short" ] } }`,
+		`{ "db_path" : "/usr/local/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false, "keys" : [ "i am too short" ] } }`,
 	},
 	{
 		"faulty json",
 		true,
 		// fails due to faulty json
-		`{ "db_path" : "/opt/ntm/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true }, "en1" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, `},
+		`{ "db_path" : "/usr/local/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true }, "en1" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, `},
 	{
 		"empty DB path",
 		true,
@@ -64,13 +64,13 @@ var tests = []struct {
 		"broken interface config",
 		true,
 		// fails due to broken interface configuration
-		`{ "db_path" : "/opt/ntm/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 0, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false } }`,
+		`{ "db_path" : "/usr/local/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 0, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false } }`,
 	},
 	{
 		"negative timeout",
 		true,
 		// fails due to negative timeout
-		`{ "db_path" : "/opt/ntm/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false, "request_timeout" : -1 } }`,
+		`{ "db_path" : "/usr/local/goProbe/db", "interfaces" : { "en0" : { "bpf_filter" : "not arp and not icmp", "buf_size" : 2097152, "promisc" : true } }, "logging" : { "destination" : "console", "level" : "debug" }, "api" : { "port" : "6060", "request_logging" : false, "request_timeout" : -1 } }`,
 	},
 }
 

--- a/cmd/goquery_completion/cmd.go
+++ b/cmd/goquery_completion/cmd.go
@@ -26,8 +26,8 @@
 //             ;;
 //
 //             *)
-//                 if [ -x /opt/ntm/goProbe/shared/goquery_completion ]; then
-//                     mapfile -t COMPREPLY < <( /opt/ntm/goProbe/shared/goquery_completion bash "${COMP_POINT}" "${COMP_LINE}" )
+//                 if [ -x /usr/local/share/goquery_completion ]; then
+//                     mapfile -t COMPREPLY < <( /usr/local/share/goquery_completion bash "${COMP_POINT}" "${COMP_LINE}" )
 //                 fi
 //             ;;
 //         esac

--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,13 @@ require (
 	github.com/json-iterator/go v1.1.6
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.7 // indirect
+	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/sirupsen/logrus v1.4.1 // indirect
+	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/throttled/throttled v2.2.4+incompatible
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxm
 github.com/go-chi/docgen v1.0.5 h1:TiGvJAuVPZJ9zFSwoF52eORe0SztOYqf9C79LVw/xbY=
 github.com/go-chi/docgen v1.0.5/go.mod h1:Nm4H4RaynSlvTexxWYWwXBzrwZKRE00MrkIIcJelhWM=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/json-iterator/go v1.1.6 h1:MrUvLMLTMxbqFJ9kzlvat/rYZqZnW3u4wkLzWTaFwKs=
@@ -25,6 +26,8 @@ github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcncea
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.7 h1:UvyT9uN+3r7yLEYSlJsbQGdsaB/a0DlgWP3pql6iwOc=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065 h1:aFkJ6lx4FPip+S+Uw4aTegFMct9shDvP+79PsSxpm3w=
+github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065/go.mod h1:7EpbotpCmVZcu+KCX4g9WaRNuu11uyhiW7+Le1dKawg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
@@ -40,11 +43,17 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/throttled/throttled v2.2.4+incompatible h1:aVKdoH/qT5Mo1Lm/678OkX2pFg7aRpHlTn1tfgaSKxs=
 github.com/throttled/throttled v2.2.4+incompatible/go.mod h1:0BjlrEGQmvxps+HuXLsyRdqpSRvJpq0PNIsOtqP9Nos=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190110200230-915654e7eabc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190419010253-1f3472d942ba h1:h0zCzEL5UW1mERvwTN6AXcc75PpLkY6OcReia6Dq1BM=
+golang.org/x/net v0.0.0-20190419010253-1f3472d942ba/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTuEGr4PN7F4XJ1p4E3Y8=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190418153312-f0ce4c0180be h1:mI+jhqkn68ybP0ORJqunXn+fq+Eeb4hHKqLQcFICjAc=
+golang.org/x/sys v0.0.0-20190418153312-f0ce4c0180be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/query/defaults.go
+++ b/pkg/query/defaults.go
@@ -2,7 +2,7 @@ package query
 
 // Defaults for query arguments
 var (
-	DefaultDBPath         = "/opt/ntm/goProbe/db"
+	DefaultDBPath         = "/usr/local/goProbe/db"
 	DefaultFormat         = "txt"
 	DefaultIn             = false
 	DefaultMaxMemPct      = 60


### PR DESCRIPTION
I cleaned up the Makefile in regards to the package paths etc. I think the product is mature and simple enough to actually adhere to OS defaults, such as using /bin and /etc and the DB path (defaults to /usr/local/goProbe/db) without any prefixes, which not only simplifies the deployment but, most importantly, removes the necessity of building the systemd script dynamically.
As a result of this simplification, the Makefile now contains a `make deb` target that creates a regular .deb file which can be installed on any amd64 Debian / Ubuntu system. After adapting the example /etc/goprobe.conf.example file to /etc/goprobe.conf, the systemd service can be started right away.