### PR TITLE
benchmark lz4

### DIFF
--- a/pkg/goDB/lz4/lz4_test.go
+++ b/pkg/goDB/lz4/lz4_test.go
@@ -36,9 +36,10 @@ func BenchmarkCompress2(b *testing.B) {
 
 	encoder := lz4.NewWriter(tmpfile)
 
-	for n:=0; n<b.N; n++ {
+	for n := 0; n < b.N; n++ {
 		if _, err := encoder.Write(data); err != nil {
 			b.Fatalf("could not compress data: %v", err)
 		}
+		encoder.Flush()
 	}
 }

--- a/pkg/goDB/lz4/lz4_test.go
+++ b/pkg/goDB/lz4/lz4_test.go
@@ -1,0 +1,44 @@
+package lz4
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/pierrec/lz4"
+)
+
+var data = []byte("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.")
+
+func BenchmarkCompress(b *testing.B) {
+	encoder := New()
+
+	tmpfile, err := ioutil.TempFile("", "compress")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	for n := 0; n < b.N; n++ {
+		if _, err := encoder.Compress(data, tmpfile); err != nil {
+			b.Fatalf("could not compress data: %v", err)
+		}
+	}
+}
+
+func BenchmarkCompress2(b *testing.B) {
+
+	tmpfile, err := ioutil.TempFile("", "compress")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	encoder := lz4.NewWriter(tmpfile)
+
+	for n:=0; n<b.N; n++ {
+		if _, err := encoder.Write(data); err != nil {
+			b.Fatalf("could not compress data: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This PR is **not** supposed to be merged. It is more intended to start a discussion about the used lz4 implementation. 
There are lz4 implementations (e.g. github.com/pierrec/lz4), that are more efficient. 

```
$ go test -bench=Compress* -benchtime=30s
goos: linux
goarch: amd64
pkg: github.com/els0r/goProbe/pkg/goDB/lz4
BenchmarkCompress-4    	 1489585	     27034 ns/op
BenchmarkCompress2-4   	68847484	       448 ns/op
PASS
ok  	github.com/els0r/goProbe/pkg/goDB/lz4	96.112s
```

What are your opinions on this?