### PR TITLE
Improve Debian package build pipeline

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -66,3 +66,4 @@ UNRELEASED fako1024,els0r
     - Add ZTSD encoder and enhance testing for encoding package
     - Improve performance of GPFile write functionality by using buffering
     - Update LZ4 to newest version (fixing potential crashes when trying to read invalid data)
+    - Improve Debian package build pipeline

--- a/README.md
+++ b/README.md
@@ -51,9 +51,19 @@ cd addon
 make all
 ```
 
-### Building for Debian
+### Building Debian package
 
-There is a Makefile target `deb-package` which compiles the software suite and provides a `.deb` file for easy installation on Debian based systems.
+There is a Makefile target `deb` which compiles the software suite and provides a `.deb` file for easy installation on Debian based systems (requires Docker). In order to build against the latest version of Go & Debian, simply run
+```
+cd addon
+make deb
+```
+
+A specific combination of Go / Debian version can be overridden by setting the `DEB_BASE_IMAGE` variable (see https://hub.docker.com/_/golang for supported Docker images), e.g.:
+```
+cd addon
+DEB_BASE_IMAGE=golang:1.19-bullseye make deb
+```
 
 goProbe
 -------------------------

--- a/addon/Dockerfile.debpkg
+++ b/addon/Dockerfile.debpkg
@@ -1,0 +1,20 @@
+ARG BASE_IMAGE=golang:latest
+FROM $BASE_IMAGE
+
+ARG DEB_VERSION=UNDEFINED
+ARG GO_PRODUCT=goProbe
+
+WORKDIR /build
+
+RUN git clone https://github.com/els0r/goProbe \
+ && cd goProbe/addon \
+ && make all \
+ && mkdir absolute/DEBIAN
+
+WORKDIR /build/goProbe/addon/absolute
+
+COPY deb-control DEBIAN/control
+COPY preinst postrm postinst DEBIAN/
+
+RUN echo "Version: $DEB_VERSION" >> DEBIAN/control \
+ && dpkg-deb --build . /${GO_PRODUCT}-${DEB_VERSION}.deb

--- a/addon/Makefile
+++ b/addon/Makefile
@@ -44,9 +44,12 @@ UNAME_OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 COMMIT_SHA := $(shell git rev-parse HEAD)
 COMMIT_SHA_SHORT := $(shell git rev-parse --short HEAD)
 GIT_VERSION := $(shell git describe --tags)
+BUILD_DATE  := $(shell date +%FT%T%z)
+
+# Debian build variables
 DEB_VERSION := $(shell echo $(GIT_VERSION) | sed 's/v//g')
 DEB_VERSION := '$(DEB_VERSION)-$(COMMIT_SHA_SHORT)'
-BUILD_DATE  := $(shell date +%FT%T%z)
+DEB_BASE_IMAGE?=golang:latest
 
 # easy to use build command for everything related goprobe
 VERSION_PATH = $(BASEPATH)/pkg/version
@@ -126,14 +129,9 @@ go_package:
 
 deb:
 
-	mkdir -p $(DEB_VERSION)/DEBIAN
-	sed 's/{{VERSION}}/$(DEB_VERSION)/g' deb-control > $(DEB_VERSION)/DEBIAN/control
-	cp preinst postrm postinst $(DEB_VERSION)/DEBIAN/
-	cp -r absolute/* $(DEB_VERSION)/
-	docker run --rm -v $(PWD)/$(DEB_VERSION):/$(DEB_VERSION) debian:buster-slim chown -R root.root $(DEB_VERSION)/{bin,etc}
-	docker run --rm -v $(PWD)/$(DEB_VERSION):/$(DEB_VERSION) -v $(PWD):/output debian:buster-slim dpkg-deb --build $(DEB_VERSION) /output/$(GO_PRODUCT)-$(DEB_VERSION).deb
-	docker run --rm -v $(PWD)/$(DEB_VERSION):/$(DEB_VERSION) debian:buster-slim rm -rf $(DEB_VERSION)/{bin,etc}
-	rm -rf $(DEB_VERSION)
+	echo "*** building Debian package against $(DEB_BASE_IMAGE) ***"
+	docker build -t goprobe:$(DEB_VERSION) --build-arg BASE_IMAGE=$(DEB_BASE_IMAGE) --build-arg DEB_VERSION=$(DEB_VERSION) --build-arg GO_PRODUCT=$(GO_PRODUCT) -f Dockerfile.deb .
+	docker run --rm --entrypoint cat goprobe:$(DEB_VERSION) /$(GO_PRODUCT)-$(DEB_VERSION).deb > $(GO_PRODUCT)-$(DEB_VERSION).deb
 
 deploy:
 
@@ -159,7 +157,5 @@ clean:
 	rm -f $(GO_PRODUCT)-$(DEB_VERSION).deb
 
 all: clean fetch compile install
-
-deb-package: clean fetch compile install deb
 
 .SILENT:

--- a/addon/Makefile
+++ b/addon/Makefile
@@ -130,7 +130,7 @@ go_package:
 deb:
 
 	echo "*** building Debian package against $(DEB_BASE_IMAGE) ***"
-	docker build -t goprobe:$(DEB_VERSION) --build-arg BASE_IMAGE=$(DEB_BASE_IMAGE) --build-arg DEB_VERSION=$(DEB_VERSION) --build-arg GO_PRODUCT=$(GO_PRODUCT) -f Dockerfile.deb .
+	docker build -t goprobe:$(DEB_VERSION) --build-arg BASE_IMAGE=$(DEB_BASE_IMAGE) --build-arg DEB_VERSION=$(DEB_VERSION) --build-arg GO_PRODUCT=$(GO_PRODUCT) -f Dockerfile.debpkg .
 	docker run --rm --entrypoint cat goprobe:$(DEB_VERSION) /$(GO_PRODUCT)-$(DEB_VERSION).deb > $(GO_PRODUCT)-$(DEB_VERSION).deb
 	docker rmi goprobe:$(DEB_VERSION)
 

--- a/addon/Makefile
+++ b/addon/Makefile
@@ -132,6 +132,7 @@ deb:
 	echo "*** building Debian package against $(DEB_BASE_IMAGE) ***"
 	docker build -t goprobe:$(DEB_VERSION) --build-arg BASE_IMAGE=$(DEB_BASE_IMAGE) --build-arg DEB_VERSION=$(DEB_VERSION) --build-arg GO_PRODUCT=$(GO_PRODUCT) -f Dockerfile.deb .
 	docker run --rm --entrypoint cat goprobe:$(DEB_VERSION) /$(GO_PRODUCT)-$(DEB_VERSION).deb > $(GO_PRODUCT)-$(DEB_VERSION).deb
+	docker rmi goprobe:$(DEB_VERSION)
 
 deploy:
 

--- a/addon/deb-control
+++ b/addon/deb-control
@@ -1,5 +1,4 @@
 Package: goprobe
-Version: {{VERSION}}
 Section: base
 Priority: optional
 Architecture: amd64


### PR DESCRIPTION
- Significant simplification of Debian package build pipeline
- Reduction of potential build issues due to GLIBC mismatches between build & deployment hosts
- More flexibility regarding target OS / version (should always support stable + previous Debian versions and _any_ Go version by simply setting one environment variable)
- Update to README to cover changes