### PR TITLE
69 revisit hostid generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/els0r/goProbe
 
 require (
-	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/els0r/status v1.0.0
 	github.com/fako1024/slimcap v0.0.0-20230310110256-894431fb9e95
 	github.com/go-chi/chi/v5 v5.0.7

--- a/go.sum
+++ b/go.sum
@@ -3,14 +3,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
-github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/els0r/status v1.0.0 h1:j2G+Iq4nZK8yNXfJqkRwBEHzHl/SReUBMg0z6SV6vqU=
 github.com/els0r/status v1.0.0/go.mod h1:O/aG4Ny1gNwOU82pIRTT1GQ1+upMDX+FA6QKwwgfSY4=
-github.com/fako1024/slimcap v0.0.0-20230301104746-c9c82bfd73ae h1:K0bC9O1IOrVI0VwNL//zcczXXny3yKk1PBNh6lLUtQg=
-github.com/fako1024/slimcap v0.0.0-20230301104746-c9c82bfd73ae/go.mod h1:VlwHE/gr+4hUMKDHTFULSmi4rEQ6UcjGJkpGre//cOE=
-github.com/fako1024/slimcap v0.0.0-20230308134807-a59af791703e h1:QurgsLqkmg19HiQeI+dEm3UiMAFYuUPIiWTCGi5irjo=
-github.com/fako1024/slimcap v0.0.0-20230308134807-a59af791703e/go.mod h1:VlwHE/gr+4hUMKDHTFULSmi4rEQ6UcjGJkpGre//cOE=
 github.com/fako1024/slimcap v0.0.0-20230310110256-894431fb9e95 h1:pvA43P6mzng0H2PUehseeMW5NxKH2/7sinmQjXh1Ynw=
 github.com/fako1024/slimcap v0.0.0-20230310110256-894431fb9e95/go.mod h1:VlwHE/gr+4hUMKDHTFULSmi4rEQ6UcjGJkpGre//cOE=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=

--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -82,7 +82,7 @@ func (qr *QueryRunner) Run(ctx context.Context, stmt *query.Statement) (res []*r
 	if err != nil {
 		return nil, fmt.Errorf("failed to get system hostname: %w", err)
 	}
-	hostID := info.GetHostID()
+	hostID := info.GetHostID(stmt.DBPath)
 
 	// start ticker to check memory consumption every second
 	heapWatchCtx, cancelHeapWatch := context.WithCancel(ctx)

--- a/pkg/goDB/info/hostid.go
+++ b/pkg/goDB/info/hostid.go
@@ -1,14 +1,81 @@
 package info
 
 import (
-	"github.com/denisbrodbeck/machineid"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	UnknownID = "UNKNOWN"
+
+	fallbackIDFileName = "host.id"
+	hostIDLen          = 16 // 128 bit in line with defaults of /etc/machine-id
 )
 
 // GetHostID is a method that returns a system's unique identifier
-func GetHostID() string {
-	id, err := machineid.ID()
+func GetHostID(fallbackPath string) string {
+	id, err := hostID()
 	if err != nil {
-		return ""
+
+		// In case a fallback location was provided, attempt to read from or
+		// generate a new host ID there
+		if fallbackPath != "" {
+			id, err = fallbackHostID(fallbackPath)
+		}
 	}
+
 	return id
+}
+
+func fallbackHostID(basePath string) (string, error) {
+
+	// Ascertain that the provided directory exists
+	if err := CheckDBExists(basePath); err != nil {
+		return UnknownID, err
+	}
+
+	// Attempt to read the fallback ID
+	fallbackIDPath := filepath.Join(basePath, fallbackIDFileName)
+	idData, err := os.ReadFile(fallbackIDPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+
+			// Fallback ID does not yet exist, generate it
+			newID, err := generateHostID()
+			if err != nil {
+				return UnknownID, fmt.Errorf("failed to generate new fallback host ID: %w", err)
+			}
+			if err = os.WriteFile(fallbackIDPath, []byte(newID), 0600); err != nil {
+				return UnknownID, fmt.Errorf("failed to store new fallback host ID: %w", err)
+			}
+
+			return newID, nil
+		}
+
+		return UnknownID, err
+	}
+
+	return sanitizeHostID(idData), nil
+}
+
+func generateHostID() (string, error) {
+	b := make([]byte, hostIDLen)
+	n, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	if n != hostIDLen {
+		return "", fmt.Errorf("incorrect number of random bytes, want %d, have %d", hostIDLen, n)
+	}
+
+	return fmt.Sprintf("%x", b), nil
+}
+
+func sanitizeHostID(idData []byte) string {
+	return strings.TrimRight(string(idData), "\n")
 }

--- a/pkg/goDB/info/hostid_default.go
+++ b/pkg/goDB/info/hostid_default.go
@@ -1,0 +1,8 @@
+//go:build !linux
+// +build !linux
+
+package info
+
+func hostID() (string, error) {
+	return UnknownID, errors.New("not implemented")
+}

--- a/pkg/goDB/info/hostid_linux.go
+++ b/pkg/goDB/info/hostid_linux.go
@@ -1,0 +1,34 @@
+//go:build linux
+// +build linux
+
+package info
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+)
+
+const (
+	machineIDPath     = "/etc/machine-id"
+	machineIDDBusPath = "/var/lib/dbus/machine-id"
+)
+
+func hostID() (string, error) {
+
+	// Attempt to read the machine ID from the main file
+	idData, err := os.ReadFile(machineIDPath)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return UnknownID, err
+		}
+
+		// Fallback to DBus based file
+		idData, err = os.ReadFile(machineIDDBusPath)
+		if err != nil {
+			return UnknownID, err
+		}
+	}
+
+	return sanitizeHostID(idData), nil
+}

--- a/pkg/goDB/info/hostid_linux.go
+++ b/pkg/goDB/info/hostid_linux.go
@@ -4,8 +4,6 @@
 package info
 
 import (
-	"errors"
-	"io/fs"
 	"os"
 )
 
@@ -19,9 +17,6 @@ func hostID() (string, error) {
 	// Attempt to read the machine ID from the main file
 	idData, err := os.ReadFile(machineIDPath)
 	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return UnknownID, err
-		}
 
 		// Fallback to DBus based file
 		idData, err = os.ReadFile(machineIDDBusPath)

--- a/pkg/goDB/info/info.go
+++ b/pkg/goDB/info/info.go
@@ -1,7 +1,9 @@
 package info
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 )
 
@@ -10,12 +12,18 @@ func CheckDBExists(path string) error {
 	if path == "" {
 		return fmt.Errorf("empty DB path provided")
 	}
-	_, err := os.Stat(path)
+	stat, err := os.Stat(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("database directory does not exist at %s", path)
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("database directory does not exist: %w", err)
 		}
+
 		return fmt.Errorf("failed to check DB directory: %w", err)
 	}
+
+	if !stat.IsDir() {
+		return fmt.Errorf("path %s is not a directory", path)
+	}
+
 	return nil
 }

--- a/pkg/goDB/info/info_test.go
+++ b/pkg/goDB/info/info_test.go
@@ -1,0 +1,94 @@
+package info
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostID(t *testing.T) {
+	id := GetHostID("")
+	require.NotEmpty(t, id)
+	require.NotContains(t, id, "\n")
+	require.Len(t, id, 32)
+}
+
+func TestHostIDErrorHandling(t *testing.T) {
+	id, err := hostID()
+	require.Nil(t, err)
+	require.NotContains(t, id, "\n")
+	require.Len(t, id, 32)
+}
+
+func TestHostIDFallback(t *testing.T) {
+	testPath, err := os.MkdirTemp("/tmp", "hostid")
+	require.Nil(t, err)
+	defer os.RemoveAll(testPath)
+
+	id, err := fallbackHostID(testPath)
+	require.Nil(t, err)
+	require.NotContains(t, id, "\n")
+	require.Len(t, id, 32)
+}
+
+func TestHostIDFallbackErrors(t *testing.T) {
+
+	// Since all of these error scenarios require specific setup / teardown, take different inputs and require
+	// different tests after execution we do not use table driven tests here
+	t.Run("empty_dir", func(t *testing.T) {
+		id, err := fallbackHostID("")
+		require.EqualError(t, err, "empty DB path provided")
+		require.Equal(t, id, UnknownID)
+	})
+
+	t.Run("invalid_dir", func(t *testing.T) {
+		id, err := fallbackHostID("/hjgfkjagdjhkad/kjagsduasgdjasg")
+		require.EqualError(t, err, "database directory does not exist: stat /hjgfkjagdjhkad/kjagsduasgdjasg: no such file or directory")
+		require.ErrorIs(t, err, fs.ErrNotExist)
+		require.Equal(t, id, UnknownID)
+	})
+
+	t.Run("invalid_permissions", func(t *testing.T) {
+		testPath, err := os.MkdirTemp("/tmp", "hostid")
+		require.Nil(t, err)
+		defer os.RemoveAll(testPath)
+		os.Chmod(testPath, 0400)
+
+		id, err := fallbackHostID(testPath)
+		require.EqualError(t, err, fmt.Errorf("open %s: permission denied", filepath.Join(testPath, fallbackIDFileName)).Error())
+		require.ErrorIs(t, err, fs.ErrPermission)
+		require.Equal(t, id, UnknownID)
+	})
+
+	t.Run("missing_write_permissions", func(t *testing.T) {
+		testPath, err := os.MkdirTemp("/tmp", "hostid")
+		require.Nil(t, err)
+		defer os.RemoveAll(testPath)
+		os.Chmod(testPath, 0500)
+
+		id, err := fallbackHostID(testPath)
+		require.EqualError(t, err, fmt.Errorf("failed to store new fallback host ID: open %s: permission denied", filepath.Join(testPath, fallbackIDFileName)).Error())
+		require.ErrorIs(t, err, fs.ErrPermission)
+		require.Equal(t, id, UnknownID)
+	})
+
+	t.Run("not_a_dir", func(t *testing.T) {
+		testPath, err := os.CreateTemp("/tmp", "hostid")
+		require.Nil(t, err)
+		defer os.RemoveAll(testPath.Name())
+
+		id, err := fallbackHostID(testPath.Name())
+		require.EqualError(t, err, fmt.Errorf("path %s is not a directory", testPath.Name()).Error())
+		require.Equal(t, id, UnknownID)
+	})
+}
+
+func TestDBExists(t *testing.T) {
+	require.EqualError(t, CheckDBExists(""), "empty DB path provided")
+	require.ErrorIs(t, CheckDBExists("/hjgfkjagdjhkad/kjagsduasgdjasg"), fs.ErrNotExist)
+	require.EqualError(t, CheckDBExists("/hjgfkjagdjhkad/kjagsduasgdjasg"), "database directory does not exist: stat /hjgfkjagdjhkad/kjagsduasgdjasg: no such file or directory")
+}


### PR DESCRIPTION
Replaces external dependency on `machineid` with custom implementation, using available options on `linux` systems. In any case, should retrieval fail, a fallback ID will be generated (on first access) and stored in the main directory of the goDB in question.

Implementations for other OSes can easily be added in the future if required.

Closes #69 