### PR TITLE
90 improve ci cd pipeline

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1,10 +1,9 @@
 name: build-packages
 
 on:
-  - push
-#  push:
-#    tags:
-#      - 'v*.*.*'
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   build-deb:
@@ -18,8 +17,7 @@ jobs:
         id: go
 
       - name: Set environment
-#        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
-        run: echo "RELEASE_VERSION=3.0.1" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -58,8 +56,7 @@ jobs:
           package: goprobe
           package_root: .debpkg
           maintainer: fako1024
-          #version: ${{ github.ref }}
-          version: v3.0.1
+          version: ${{ github.ref }}
           arch: 'amd64'
           depends: 'liblz4-1, libzstd1'
           desc: 'goProbe Network Traffic Monitoring'
@@ -84,8 +81,7 @@ jobs:
         id: go
 
       - name: Set environment
-#        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
-        run: echo "RELEASE_VERSION=3.0.1" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
 
       - name: Install OS dependencies
         run: dnf -y install gcc libzstd-devel lz4-devel
@@ -118,8 +114,7 @@ jobs:
           package: goprobe
           package_root: .rpmpkg
           maintainer: fako1024
-          #version: ${{ github.ref }}
-          version: v3.0.1
+          version: ${{ github.ref }}
           arch: 'x86_64'
           desc: 'goProbe Network Traffic Monitoring'
 

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -26,15 +26,18 @@ jobs:
         run: |
           GOOS=linux GOARCH=amd64 go build -a -o goProbe ./cmd/goProbe
           GOOS=linux GOARCH=amd64 go build -a -o goQuery ./cmd/goQuery
+          GOOS=linux GOARCH=amd64 go build -a -o goConvert ./cmd/goConvert
 
       - name: Deploy artifacts
         run: |
           mkdir -p .debpkg/usr/local/bin
           mkdir -p .debpkg/etc/systemd/system
 
-          # Binaries
+          # Binaries / Tarball
           cp goProbe .debpkg/usr/local/bin/goProbe
           cp goQuery .debpkg/usr/local/bin/goQuery
+          cp goConvert .debpkg/usr/local/bin/goConvert
+          tar czf goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz goProbe goQuery goConvert
 
           # Config
           cp addon/goprobe.conf.example .debpkg/etc/goprobe.conf.example
@@ -62,10 +65,14 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Debian Package
-          path: ./goprobe_${{ env.RELEASE_VERSION }}_amd64.deb
+          path: |
+            ./goprobe_${{ env.RELEASE_VERSION }}_amd64.deb
+            ./goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: goprobe_${{ env.RELEASE_VERSION }}_amd64.deb
+          files: |
+            goprobe_${{ env.RELEASE_VERSION }}_amd64.deb
+            goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz
           generate_release_notes: true

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -68,3 +68,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: goprobe_${{ env.RELEASE_VERSION }}_amd64.deb
+          generate_release_notes: true

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -18,7 +18,8 @@ jobs:
         id: go
 
       - name: Set environment
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+#        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=3.0.1" >> $GITHUB_ENV
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -38,7 +39,7 @@ jobs:
           cp goProbe .debpkg/usr/local/bin/goProbe
           cp goQuery .debpkg/usr/local/bin/goQuery
           cp goConvert .debpkg/usr/local/bin/goConvert
-          tar czf goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz goProbe goQuery goConvert
+          tar czf ./goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz goProbe goQuery goConvert
 
           # Config
           cp addon/goprobe.conf.example .debpkg/etc/goprobe.conf.example
@@ -57,7 +58,8 @@ jobs:
           package: goprobe
           package_root: .debpkg
           maintainer: fako1024
-          version: ${{ github.ref }}
+          #version: ${{ github.ref }}
+          version: v3.0.1
           arch: 'amd64'
           depends: 'liblz4-1, libzstd1'
           desc: 'goProbe Network Traffic Monitoring'
@@ -81,7 +83,8 @@ jobs:
         id: go
 
       - name: Set environment
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+#        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=3.0.1" >> $GITHUB_ENV
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -101,7 +104,7 @@ jobs:
           cp goProbe .rpmpkg/usr/local/bin/goProbe
           cp goQuery .rpmpkg/usr/local/bin/goQuery
           cp goConvert .rpmpkg/usr/local/bin/goConvert
-          tar czf goprobe_${{ env.RELEASE_VERSION }}_fedora_x86_64.tar.gz goProbe goQuery goConvert
+          tar czf ./goprobe_${{ env.RELEASE_VERSION }}_fedora_x86_64.tar.gz goProbe goQuery goConvert
 
           # Config
           cp addon/goprobe.conf.example .rpmpkg/etc/goprobe.conf.example
@@ -111,7 +114,8 @@ jobs:
           package: goprobe
           package_root: .rpmpkg
           maintainer: fako1024
-          version: ${{ github.ref }}
+          #version: ${{ github.ref }}
+          version: v3.0.1
           arch: 'x86_64'
           desc: 'goProbe Network Traffic Monitoring'
 

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -73,7 +73,8 @@ jobs:
             ./goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz
 
   build-rpm:
-    runs-on: fedora-latest
+    runs-on: ubuntu-latest
+    container: fedora:37
     steps:
 
       - name: Set up Go

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1,9 +1,10 @@
 name: build-packages
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  - push
+#  push:
+#    tags:
+#      - 'v*.*.*'
 
 jobs:
   build-deb:
@@ -69,10 +70,74 @@ jobs:
             ./goprobe_${{ env.RELEASE_VERSION }}_amd64.deb
             ./goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz
 
+  build-rpm:
+    runs-on: fedora-latest
+    steps:
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.18
+        id: go
+
+      - name: Set environment
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Build for AMD64
+        run: |
+          GOOS=linux GOARCH=amd64 go build -a -o goProbe ./cmd/goProbe
+          GOOS=linux GOARCH=amd64 go build -a -o goQuery ./cmd/goQuery
+          GOOS=linux GOARCH=amd64 go build -a -o goConvert ./cmd/goConvert
+
+      - name: Deploy artifacts
+        run: |
+          mkdir -p .rpmpkg/usr/local/bin
+          mkdir -p .rpmpkg/etc/systemd/system
+
+          # Binaries / Tarball
+          cp goProbe .rpmpkg/usr/local/bin/goProbe
+          cp goQuery .rpmpkg/usr/local/bin/goQuery
+          cp goConvert .rpmpkg/usr/local/bin/goConvert
+          tar czf goprobe_${{ env.RELEASE_VERSION }}_fedora_x86_64.tar.gz goProbe goQuery goConvert
+
+          # Config
+          cp addon/goprobe.conf.example .rpmpkg/etc/goprobe.conf.example
+          cp addon/goprobe.service .rpmpkg/etc/systemd/system/goprobe.service
+      - uses: jiro4989/build-rpm-action@v2
+        with:
+          package: goprobe
+          package_root: .rpmpkg
+          maintainer: fako1024
+          version: ${{ github.ref }}
+          arch: 'x86_64'
+          desc: 'goProbe Network Traffic Monitoring'
+
+      - name: Store artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Fedora Package
+          path: |
+            ./goprobe_${{ env.RELEASE_VERSION }}_x86_64.rpm
+            ./goprobe_${{ env.RELEASE_VERSION }}_fedora_x86_64.tar.gz
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build-deb, build-rpm]
+    steps:
+
+      - uses: actions/download-artifact@v3
+        with:
+          path: downloaded-artifacts
+
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            goprobe_${{ env.RELEASE_VERSION }}_amd64.deb
-            goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz
+            downloaded-artifacts/goprobe_${{ env.RELEASE_VERSION }}_amd64.deb
+            downloaded-artifacts/goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz
+            downloaded-artifacts/goprobe_${{ env.RELEASE_VERSION }}_x86_64.rpm
+            downloaded-artifacts/goprobe_${{ env.RELEASE_VERSION }}_fedora_x86_64.tar.gz 
           generate_release_notes: true

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           name: Fedora Package
           path: |
-            ./goprobe_${{ env.RELEASE_VERSION }}_x86_64.rpm
+            ./goprobe-${{ env.RELEASE_VERSION }}*x86_64.rpm
             ./goprobe_${{ env.RELEASE_VERSION }}_fedora_x86_64.tar.gz
 
   release:
@@ -140,12 +140,15 @@ jobs:
         with:
           path: downloaded-artifacts
 
+      - name: List artifacts
+        run: ls -al downloaded-artifacts
+
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             downloaded-artifacts/goprobe_${{ env.RELEASE_VERSION }}_amd64.deb
             downloaded-artifacts/goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz
-            downloaded-artifacts/goprobe_${{ env.RELEASE_VERSION }}_x86_64.rpm
+            downloaded-artifacts/goprobe-${{ env.RELEASE_VERSION }}*x86_64.rpm
             downloaded-artifacts/goprobe_${{ env.RELEASE_VERSION }}_fedora_x86_64.tar.gz 
           generate_release_notes: true

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -87,6 +87,9 @@ jobs:
 #        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
         run: echo "RELEASE_VERSION=3.0.1" >> $GITHUB_ENV
 
+      - name: Install OS dependencies
+        run: dnf -y install gcc libzstd-devel lz4-devel
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 


### PR DESCRIPTION
Adds binary upload, automatic release notes creation (for an example see [here](https://github.com/fako1024/gatt/releases/tag/v1.0.3)) and first shot at `rpm` build pipeline. Once merged I'll create another test tag to see if all works well, then close the issue manually.