### PR TITLE
Generalize upload rules to catch all files

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -142,8 +142,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            downloaded-artifacts/Debian/goprobe_${{ env.RELEASE_VERSION }}_amd64.deb
-            downloaded-artifacts/Debian/goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz
-            downloaded-artifacts/Fedora/goprobe-${{ env.RELEASE_VERSION }}*x86_64.rpm
-            downloaded-artifacts/Fedora/goprobe_${{ env.RELEASE_VERSION }}_fedora_x86_64.tar.gz 
+            downloaded-artifacts/Debian/goprobe*.deb
+            downloaded-artifacts/Debian/goprobe*.tar.gz
+            downloaded-artifacts/Fedora/goprobe*.rpm
+            downloaded-artifacts/Fedora/goprobe*.tar.gz 
           generate_release_notes: true


### PR DESCRIPTION
Hopefully the last attempt, was missing the `${{ env.RELEASE_VERSION }}` created in the above steps and decided to be more generic (in case we add more files in the future).