### PR TITLE
[feature][security] Unify permissions and add configurability goDB data

### DIFF
--- a/cmd/goProbe/config/config.go
+++ b/cmd/goProbe/config/config.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"sync"
 
@@ -45,8 +46,9 @@ type Config struct {
 }
 
 type DBConfig struct {
-	Path        string `json:"path"`
-	EncoderType string `json:"encoder_type"`
+	Path        string      `json:"path"`
+	EncoderType string      `json:"encoder_type"`
+	Permissions fs.FileMode `json:"permissions"`
 }
 
 type CaptureConfig struct {

--- a/cmd/goProbe/goProbe.go
+++ b/cmd/goProbe/goProbe.go
@@ -139,6 +139,10 @@ func main() {
 	if err != nil {
 		logger.Fatalf("failed to get encoder type from %s: %v", config.DB.EncoderType, err)
 	}
+	dbPermissions := goDB.DefaultPermissions
+	if config.DB.Permissions != 0 {
+		dbPermissions = config.DB.Permissions
+	}
 
 	// Initialize packet logger
 	ifaces := make([]string, len(config.Interfaces))
@@ -199,7 +203,8 @@ func main() {
 
 	// start goroutine for writeouts
 	writeoutHandler := writeout.NewHandler(captureManager, encoderType).
-		WithSyslogWriting(config.SyslogFlows)
+		WithSyslogWriting(config.SyslogFlows).
+		WithPermissions(dbPermissions)
 
 	// start writeout handler
 	doneWriting := writeoutHandler.HandleWriteouts()

--- a/pkg/goDB/db_writer_test.go
+++ b/pkg/goDB/db_writer_test.go
@@ -26,7 +26,7 @@ func TestPanicDuringWrite(t *testing.T) {
 	dayUnix := time.Unix(dayTimestamp, 0)
 	dirPath := filepath.Join(filepath.Join(tempDir, "test"), strconv.Itoa(dayUnix.Year()), fmt.Sprintf("%02d", dayUnix.Month()), strconv.Itoa(int(dayTimestamp)))
 
-	w := NewDBWriter(tempDir, "test", encoders.EncoderTypeNull)
+	w := NewDBWriter(tempDir, "test", encoders.EncoderTypeNull).Permissions(0600)
 
 	// Add a single item that will trigger a panic later
 	testMap := hashmap.NewAggFlowMap()


### PR DESCRIPTION
Couldn't resist and added configurability throughout the chain and for all tools / binaries. Default is now `0644` (files) and `0755` (directories) so that default behavior is unchanged and permissive, as discussed.

Closes #85 