### PR TITLE
[bugfix] Straighten out command-line error handling

### DIFF
--- a/cmd/goQuery/commands/root.go
+++ b/cmd/goQuery/commands/root.go
@@ -38,7 +38,7 @@ var subRootCmd = &cobra.Command{}
 // Execute is the main entrypoint and runs the CLI tool
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		logging.Logger().Fatalf("Error running query: %s", err)
+		cliLogger.Fatalf("Error running query: %s", err)
 	}
 }
 
@@ -50,6 +50,7 @@ var (
 )
 
 func init() {
+	initCLILogger()
 	initLogger()
 
 	// flags to be also passed to children commands
@@ -91,6 +92,20 @@ func init() {
 
 	// Duration
 	rootCmd.Flags().DurationVarP(&cmdLineParams.QueryTimeout, "timeout", "", query.DefaultQueryTimeout, helpMap["QueryTimeout"])
+}
+
+var cliLogger *logging.L
+
+func initCLILogger() {
+	var err error
+	// TODO: switch to logging.EncodingPlain once https://github.com/els0r/goProbe/pull/110 is merged
+	cliLogger, err = logging.New(logging.LevelError, logging.EncodingLogfmt,
+		logging.WithOutput(os.Stderr),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to instantiate CLI logger: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func initLogger() {

--- a/cmd/goQuery/commands/root.go
+++ b/cmd/goQuery/commands/root.go
@@ -98,8 +98,7 @@ var cliLogger *logging.L
 
 func initCLILogger() {
 	var err error
-	// TODO: switch to logging.EncodingPlain once https://github.com/els0r/goProbe/pull/110 is merged
-	cliLogger, err = logging.New(logging.LevelError, logging.EncodingLogfmt,
+	cliLogger, err = logging.New(logging.LevelError, logging.EncodingPlain,
 		logging.WithOutput(os.Stderr),
 	)
 	if err != nil {

--- a/cmd/goQuery/commands/root.go
+++ b/cmd/goQuery/commands/root.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/els0r/goProbe/pkg/goDB/engine"
@@ -25,6 +25,7 @@ var rootCmd = &cobra.Command{
 	Use:   "goQuery [flags] [" + supportedCmds + "]",
 	Short: helpBase,
 	Long:  helpBaseLong,
+
 	// entry point for goQuery
 	RunE:          entrypoint,
 	SilenceUsage:  true,
@@ -36,11 +37,9 @@ var subRootCmd = &cobra.Command{}
 
 // Execute is the main entrypoint and runs the CLI tool
 func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
+	if err := rootCmd.Execute(); err != nil {
+		logging.Logger().Fatalf("Error running query: %s", err)
 	}
-	return
 }
 
 // globally accessible variable for other packages
@@ -51,7 +50,7 @@ var (
 )
 
 func init() {
-	cobra.OnInitialize(initLogger)
+	initLogger()
 
 	// flags to be also passed to children commands
 	subRootCmd.PersistentFlags().StringVarP(&subcmdLineParams.DBPath, "db-path", "d", query.DefaultDBPath, helpMap["DBPath"])
@@ -118,10 +117,8 @@ func entrypoint(cmd *cobra.Command, args []string) error {
 	// run commands that don't require any argument
 	// handle list flag
 	if cmdLineParams.List {
-		err := listInterfaces(cmdLineParams.DBPath, cmdLineParams.External)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to retrieve list of available databases: %s", err)
-			return err
+		if err := listInterfaces(cmdLineParams.DBPath, cmdLineParams.External); err != nil {
+			return fmt.Errorf("failed to retrieve list of available databases: %w", err)
 		}
 		return nil
 	}
@@ -135,25 +132,18 @@ func entrypoint(cmd *cobra.Command, args []string) error {
 	// check if arguments should be loaded from disk. The cmdLineParams are taken as
 	// the base for this to allow modification of single parameters
 	if argsLocation != "" {
-		argumentsJSON, err := ioutil.ReadFile(argsLocation)
+		argumentsJSON, err := os.ReadFile(filepath.Clean(argsLocation))
 		if err != nil {
-			err := fmt.Errorf("Failed to read query args from %s", argsLocation)
-			fmt.Fprintf(os.Stderr, "%s", err)
-			return err
+			return fmt.Errorf("failed to read query args from %s: %w", argsLocation, err)
 		}
 		// unmarshal arguments into the command line parameters
-		err = json.Unmarshal(argumentsJSON, &queryArgs)
-		if err != nil {
-			err := fmt.Errorf("Failed to parse JSON query args %s", err)
-			fmt.Fprintf(os.Stderr, "%s", err)
-			return err
+		if err = json.Unmarshal(argumentsJSON, &queryArgs); err != nil {
+			return fmt.Errorf("failed to parse JSON query args %s: %w", string(argumentsJSON), err)
 		}
 	} else {
 		// check that query type or other subcommands were provided
 		if len(args) == 0 {
-			err := errors.New("No query type or command provided")
-			fmt.Fprintf(os.Stderr, "%s\n%s\n", err, cmd.Long)
-			return err
+			return errors.New("no query type or command provided")
 		}
 		if args[0] == "help" {
 			cmd.Help()
@@ -172,8 +162,7 @@ func entrypoint(cmd *cobra.Command, args []string) error {
 		for _, c := range subRootCmd.Commands() {
 			if c.Name() == args[0] {
 				c.SetArgs(args[1:])
-				err := c.Execute()
-				return err
+				return c.Execute()
 			}
 		}
 
@@ -186,8 +175,7 @@ func entrypoint(cmd *cobra.Command, args []string) error {
 	// convert the command line parameters
 	stmt, err := queryArgs.Prepare()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Query preparation failed: %v\n", err)
-		return err
+		return fmt.Errorf("failed to prepare query: %w", err)
 	}
 
 	var ctx context.Context
@@ -204,8 +192,7 @@ func entrypoint(cmd *cobra.Command, args []string) error {
 
 	res, err := engine.NewQueryRunner().Run(ctx, stmt)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Query execution failed: %v\n", err)
-		return err
+		return fmt.Errorf("failed to execute query %s: %w", stmt, err)
 	}
 	// empty results should be handled here exclusively
 	if len(res) == 0 {
@@ -220,10 +207,8 @@ func entrypoint(cmd *cobra.Command, args []string) error {
 
 	// serialize raw results array if json is selected
 	if stmt.Format == "json" {
-		err = jsoniter.NewEncoder(stmt.Output).Encode(res)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Results serialization failed: %v\n", err)
-			return err
+		if err = jsoniter.NewEncoder(stmt.Output).Encode(res); err != nil {
+			return fmt.Errorf("failed to serialize query results: %w", err)
 		}
 		return nil
 	}
@@ -235,10 +220,8 @@ func entrypoint(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	err = stmt.Print(ctx, result)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Result printing failed: %v\n", err)
-		return err
+	if err = stmt.Print(ctx, result); err != nil {
+		return fmt.Errorf("failed to print query result: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
What I've done:

- Replaced all manual error handling / output in the `cobra` entrypoint function to simply return the error to the caller
- Handle any error from that function in `Execute()`, using "our" logger with its `Fatalf()` method
- Initialize our logger directly in `init()` instead of via `cobra` (to ensure it's already initialized if the error occurs before `cobra` can call the initializer)

@els0r For now I've kept this a draft because there are two open questions IMHO:

- [x] Should we maybe add a special formatter for the command line tool(s)? Right now we throw a message like this:
```
ts=2023-04-11T11:23:51.976+02:00 level=fatal msg="Error running query: failed to prepare query: failed to parse query type: Unknown attribute name: 'protod'" version=872abf81
```
TBH I don't think that someone running a CLI expects a "logger" style response but rather something like:
```
Error running query: failed to prepare query: failed to parse query type: Unknown attribute name: 'protod'
```
- [x] ~~The same changes should probably be applied to `global-query` (because the same problem about not notifying errors happens there as indicated in #43 )~~

What's your take on those open questions?

Closes #104 