### PR TITLE
[feature] Support for explicit logger instantiation

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -78,7 +78,7 @@ const (
 func getLoggerHandler() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
-			logger := logging.WithContext(r.Context())
+			logger := logging.FromContext(r.Context())
 			logger.Debugf("%s %s", r.Method, r.URL.Path)
 			next.ServeHTTP(w, r)
 		}

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -27,7 +27,7 @@ func (a *authenticator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 
 	ctx := r.Context()
-	logger := logging.WithContext(ctx)
+	logger := logging.FromContext(ctx)
 
 	select {
 	case <-ctx.Done():

--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -28,7 +28,7 @@ func NewStandardHandler() *StandardHandler {
 // Handle is a convenience method to return a standard formatted http Error and
 // write a log line if a logger is provided
 func (s *StandardHandler) Handle(ctx context.Context, w http.ResponseWriter, statusCode int, err error, msg string) {
-	logger := logging.WithContext(ctx)
+	logger := logging.FromContext(ctx)
 
 	http.Error(w, fmt.Sprintf("%s: %s", http.StatusText(statusCode), msg), statusCode)
 	logger.Errorf("%s: %v", msg, err)

--- a/pkg/api/v1/post_routes.go
+++ b/pkg/api/v1/post_routes.go
@@ -22,7 +22,7 @@ func (a *API) postRequestRoutes(r chi.Router) {
 
 func (a *API) handleReload(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	logger := logging.WithContext(ctx)
+	logger := logging.FromContext(ctx)
 
 	pp := printPretty(r)
 

--- a/pkg/capture/capture_manager.go
+++ b/pkg/capture/capture_manager.go
@@ -94,7 +94,7 @@ func (cm *Manager) enable(ifaces map[string]config.CaptureConfig) {
 
 			cm.setCapture(iface, &ManagedCapture{capture: capture, cancel: cancel})
 
-			logger := logging.WithContext(capture.ctx)
+			logger := logging.FromContext(capture.ctx)
 			logger.Info(fmt.Sprintf("added interface to capture list"))
 
 			capture.Run()
@@ -177,7 +177,7 @@ func (cm *Manager) capturesCopy() map[string]*ManagedCapture {
 //
 // Returns once all the above actions have been completed.
 func (cm *Manager) Update(ifaces config.Ifaces, returnChan chan TaggedAggFlowMap) {
-	logger := logging.WithContext(cm.ctx)
+	logger := logging.FromContext(cm.ctx)
 
 	t0 := time.Now()
 
@@ -216,7 +216,7 @@ func (cm *Manager) Update(ifaces config.Ifaces, returnChan chan TaggedAggFlowMap
 		})
 
 		// close capture and delete from list of managed captures
-		logger = logging.WithContext(mc.capture.ctx)
+		logger = logging.FromContext(mc.capture.ctx)
 
 		mc.cancel()
 		cm.delCapture(iface)
@@ -303,7 +303,7 @@ func (cm *Manager) ErrorsAll() map[string]ErrorMap {
 // The resulting TaggedAggFlowMaps will be sent over returnChan and
 // be tagged with the given timestamp.
 func (cm *Manager) RotateAll(returnChan chan TaggedAggFlowMap) {
-	logger := logging.WithContext(cm.ctx)
+	logger := logging.FromContext(cm.ctx)
 
 	t0 := time.Now()
 

--- a/pkg/goDB/DBWorkManager.go
+++ b/pkg/goDB/DBWorkManager.go
@@ -240,7 +240,7 @@ func (w *DBWorkManager) grabAndProcessWorkload(ctx context.Context, wg *sync.Wai
 	go func() {
 		defer wg.Done()
 
-		logger := logging.WithContext(ctx)
+		logger := logging.FromContext(ctx)
 
 		enc, err := encoder.New(defaultEncoderType)
 		if err != nil {

--- a/pkg/goprobe/writeout/handler.go
+++ b/pkg/goprobe/writeout/handler.go
@@ -76,7 +76,7 @@ func (w *writeout) close() {
 const tFormat = "2006-01-02 15:04:05 -0700 MST"
 
 func (h *Handler) FullWriteout(ctx context.Context, at time.Time) error {
-	logger := logging.WithContext(ctx)
+	logger := logging.FromContext(ctx)
 
 	// don't rotate if a bogus timestamp is supplied
 	if at.Sub(h.LastRotation) < 0 {
@@ -103,7 +103,7 @@ func (h *Handler) FullWriteout(ctx context.Context, at time.Time) error {
 }
 
 func (h *Handler) UpdateAndRotate(ctx context.Context, ifaces config.Ifaces, at time.Time) error {
-	logger := logging.WithContext(ctx)
+	logger := logging.FromContext(ctx)
 
 	// don't rotate if a bogus timestamp is supplied
 	if at.Sub(h.LastRotation) < 0 {
@@ -131,7 +131,7 @@ func (h *Handler) UpdateAndRotate(ctx context.Context, ifaces config.Ifaces, at 
 
 func (h *Handler) HandleRotations(ctx context.Context, interval time.Duration) {
 	go func() {
-		logger := logging.WithContext(ctx)
+		logger := logging.FromContext(ctx)
 
 		// wait until the next 5 minute interval of the hour is reached before starting the ticker
 		tNow := time.Now()

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -44,10 +44,10 @@ func TestLogConcurrent(t *testing.T) {
 	}
 
 	t.Run("samectxhierarchy", func(t *testing.T) {
-		ctx := NewContext(context.Background(), "hello", "world")
+		ctx := WithFields(context.Background(), "hello", "world")
 		numConcurrent := 32
 
-		logger := WithContext(ctx)
+		logger := FromContext(ctx)
 		logger.Info("before go-routines")
 
 		var wg sync.WaitGroup
@@ -56,14 +56,14 @@ func TestLogConcurrent(t *testing.T) {
 			go func(n int, ctx context.Context) {
 				defer wg.Done()
 
-				f1ctx := NewContext(ctx, "fval", n)
-				l2 := WithContext(f1ctx)
+				f1ctx := WithFields(ctx, "fval", n)
+				l2 := FromContext(f1ctx)
 				l2.Infof("f%d", n)
 			}(i, ctx)
 		}
 		wg.Wait()
 
-		logger = WithContext(ctx)
+		logger = FromContext(ctx)
 		logger.Infof("after %d go-routines", numConcurrent)
 	})
 }
@@ -291,7 +291,7 @@ func TestCustomLogMessages(t *testing.T) {
 	}
 
 	t.Run("testformatting", func(t *testing.T) {
-		logger := WithContext(context.Background())
+		logger := FromContext(context.Background())
 		// the next two lines shouldn't show up due to level "info" in init
 		logger.With("level_num", LevelDebug).Debug("f")
 		logger.Debugf("f%d", LevelDebug)
@@ -307,13 +307,13 @@ func TestCustomLogMessages(t *testing.T) {
 	})
 
 	t.Run("fatal", func(t *testing.T) {
-		logger := WithContext(nil).exiter(mockExiter{t})
+		logger := FromContext(nil).exiter(mockExiter{t})
 		logger.With("left", 42).Fatal("this my dearest friends, is where I leave you")
 		logger.Fatalf("this my dearest friends, is where I leave %s", "you")
 	})
 
 	t.Run("panic", func(t *testing.T) {
-		logger := WithContext(nil).panicker(mockPanicker{t})
+		logger := FromContext(nil).panicker(mockPanicker{t})
 		logger.With("left", 24).Panic("this my dearest friends, is where I leave you")
 		logger.Panicf("this my dearest friends, is where I leave %s", "you")
 	})
@@ -321,13 +321,13 @@ func TestCustomLogMessages(t *testing.T) {
 
 // tests the edge cases in context creation
 func TestNewContext(t *testing.T) {
-	ctx := NewContext(nil)
+	ctx := WithFields(nil)
 	require.NotNil(t, ctx)
 
-	ctx = NewContext(nil, "hello")
+	ctx = WithFields(nil, "hello")
 	require.NotNil(t, ctx)
 
-	ctx = NewContext(nil, 3, "hello")
+	ctx = WithFields(nil, 3, "hello")
 	require.NotNil(t, ctx)
 }
 


### PR DESCRIPTION
Also changes the logging API with regards to naming when fields are added to the context or when a logger is derived _from_ a context.