### PR TITLE
[bugfix] Enforce deterministic result order for flows / entries with identical counters

### DIFF
--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -239,6 +239,20 @@ func (a Attributes) String() string {
 	)
 }
 
+// Less returns wether the set of attributes a sorts before a2
+func (a Attributes) Less(a2 Attributes) bool {
+	if a.SrcIP != a2.SrcIP {
+		return a.SrcIP.Less(a2.SrcIP)
+	}
+	if a.DstIP != a2.DstIP {
+		return a.DstIP.Less(a2.DstIP)
+	}
+	if a.IPProto != a2.IPProto {
+		return a.IPProto < a2.IPProto
+	}
+	return a.DstPort < a2.DstPort
+}
+
 // Rows is a list of results
 type Rows []Row
 

--- a/pkg/results/sort.go
+++ b/pkg/results/sort.go
@@ -100,14 +100,14 @@ func By(sort SortOrder, direction types.Direction, ascending bool) by {
 			if ascending {
 				return func(e1, e2 *Row) bool {
 					if e1.Counters.PacketsSent+e1.Counters.PacketsRcvd == e2.Counters.PacketsSent+e2.Counters.PacketsRcvd {
-						return e1.Attributes.String() < e2.Attributes.String()
+						return e1.Attributes.Less(e2.Attributes)
 					}
 					return e1.Counters.PacketsSent+e1.Counters.PacketsRcvd < e2.Counters.PacketsSent+e2.Counters.PacketsRcvd
 				}
 			}
 			return func(e1, e2 *Row) bool {
 				if e1.Counters.PacketsSent+e1.Counters.PacketsRcvd == e2.Counters.PacketsSent+e2.Counters.PacketsRcvd {
-					return e1.Attributes.String() > e2.Attributes.String()
+					return e2.Attributes.Less(e1.Attributes)
 				}
 				return e1.Counters.PacketsSent+e1.Counters.PacketsRcvd > e2.Counters.PacketsSent+e2.Counters.PacketsRcvd
 			}
@@ -115,14 +115,14 @@ func By(sort SortOrder, direction types.Direction, ascending bool) by {
 			if ascending {
 				return func(e1, e2 *Row) bool {
 					if e1.Counters.PacketsRcvd == e2.Counters.PacketsRcvd {
-						return e1.Attributes.String() < e2.Attributes.String()
+						return e1.Attributes.Less(e2.Attributes)
 					}
 					return e1.Counters.PacketsRcvd < e2.Counters.PacketsRcvd
 				}
 			}
 			return func(e1, e2 *Row) bool {
 				if e1.Counters.PacketsRcvd == e2.Counters.PacketsRcvd {
-					return e1.Attributes.String() > e2.Attributes.String()
+					return e2.Attributes.Less(e1.Attributes)
 				}
 				return e1.Counters.PacketsRcvd > e2.Counters.PacketsRcvd
 			}
@@ -130,14 +130,14 @@ func By(sort SortOrder, direction types.Direction, ascending bool) by {
 			if ascending {
 				return func(e1, e2 *Row) bool {
 					if e1.Counters.PacketsSent == e2.Counters.PacketsSent {
-						return e1.Attributes.String() < e2.Attributes.String()
+						return e1.Attributes.Less(e2.Attributes)
 					}
 					return e1.Counters.PacketsSent < e2.Counters.PacketsSent
 				}
 			}
 			return func(e1, e2 *Row) bool {
 				if e1.Counters.PacketsSent == e2.Counters.PacketsSent {
-					return e1.Attributes.String() > e2.Attributes.String()
+					return e2.Attributes.Less(e1.Attributes)
 				}
 				return e1.Counters.PacketsSent > e2.Counters.PacketsSent
 			}
@@ -148,14 +148,14 @@ func By(sort SortOrder, direction types.Direction, ascending bool) by {
 			if ascending {
 				return func(e1, e2 *Row) bool {
 					if e1.Counters.BytesSent+e1.Counters.BytesRcvd == e2.Counters.BytesSent+e2.Counters.BytesRcvd {
-						return e1.Attributes.String() < e2.Attributes.String()
+						return e1.Attributes.Less(e2.Attributes)
 					}
 					return e1.Counters.BytesSent+e1.Counters.BytesRcvd < e2.Counters.BytesSent+e2.Counters.BytesRcvd
 				}
 			}
 			return func(e1, e2 *Row) bool {
 				if e1.Counters.BytesSent+e1.Counters.BytesRcvd == e2.Counters.BytesSent+e2.Counters.BytesRcvd {
-					return e1.Attributes.String() > e2.Attributes.String()
+					return e2.Attributes.Less(e1.Attributes)
 				}
 				return e1.Counters.BytesSent+e1.Counters.BytesRcvd > e2.Counters.BytesSent+e2.Counters.BytesRcvd
 			}
@@ -163,14 +163,14 @@ func By(sort SortOrder, direction types.Direction, ascending bool) by {
 			if ascending {
 				return func(e1, e2 *Row) bool {
 					if e1.Counters.BytesRcvd == e2.Counters.BytesRcvd {
-						return e1.Attributes.String() < e2.Attributes.String()
+						return e1.Attributes.Less(e2.Attributes)
 					}
 					return e1.Counters.BytesRcvd < e2.Counters.BytesRcvd
 				}
 			}
 			return func(e1, e2 *Row) bool {
 				if e1.Counters.BytesRcvd == e2.Counters.BytesRcvd {
-					return e1.Attributes.String() > e2.Attributes.String()
+					return e2.Attributes.Less(e1.Attributes)
 				}
 				return e1.Counters.BytesRcvd > e2.Counters.BytesRcvd
 			}
@@ -178,14 +178,14 @@ func By(sort SortOrder, direction types.Direction, ascending bool) by {
 			if ascending {
 				return func(e1, e2 *Row) bool {
 					if e1.Counters.BytesSent == e2.Counters.BytesSent {
-						return e1.Attributes.String() < e2.Attributes.String()
+						return e1.Attributes.Less(e2.Attributes)
 					}
 					return e1.Counters.BytesSent < e2.Counters.BytesSent
 				}
 			}
 			return func(e1, e2 *Row) bool {
 				if e1.Counters.BytesSent == e2.Counters.BytesSent {
-					return e1.Attributes.String() > e2.Attributes.String()
+					return e2.Attributes.Less(e1.Attributes)
 				}
 				return e1.Counters.BytesSent > e2.Counters.BytesSent
 			}
@@ -194,14 +194,14 @@ func By(sort SortOrder, direction types.Direction, ascending bool) by {
 		if ascending {
 			return func(e1, e2 *Row) bool {
 				if e1.Labels.Timestamp.Equal(e2.Labels.Timestamp) {
-					return e1.Attributes.String() < e2.Attributes.String()
+					return e1.Attributes.Less(e2.Attributes)
 				}
 				return e1.Labels.Timestamp.Before(e2.Labels.Timestamp)
 			}
 		}
 		return func(e1, e2 *Row) bool {
 			if e1.Labels.Timestamp.Equal(e2.Labels.Timestamp) {
-				return e1.Attributes.String() > e2.Attributes.String()
+				return e2.Attributes.Less(e1.Attributes)
 			}
 			return e1.Labels.Timestamp.After(e2.Labels.Timestamp)
 		}

--- a/pkg/results/sort.go
+++ b/pkg/results/sort.go
@@ -99,28 +99,46 @@ func By(sort SortOrder, direction types.Direction, ascending bool) by {
 		case types.DirectionBoth, types.DirectionSum:
 			if ascending {
 				return func(e1, e2 *Row) bool {
+					if e1.Counters.PacketsSent+e1.Counters.PacketsRcvd == e2.Counters.PacketsSent+e2.Counters.PacketsRcvd {
+						return e1.Attributes.String() < e2.Attributes.String()
+					}
 					return e1.Counters.PacketsSent+e1.Counters.PacketsRcvd < e2.Counters.PacketsSent+e2.Counters.PacketsRcvd
 				}
 			}
 			return func(e1, e2 *Row) bool {
+				if e1.Counters.PacketsSent+e1.Counters.PacketsRcvd == e2.Counters.PacketsSent+e2.Counters.PacketsRcvd {
+					return e1.Attributes.String() > e2.Attributes.String()
+				}
 				return e1.Counters.PacketsSent+e1.Counters.PacketsRcvd > e2.Counters.PacketsSent+e2.Counters.PacketsRcvd
 			}
 		case types.DirectionIn:
 			if ascending {
 				return func(e1, e2 *Row) bool {
+					if e1.Counters.PacketsRcvd == e2.Counters.PacketsRcvd {
+						return e1.Attributes.String() < e2.Attributes.String()
+					}
 					return e1.Counters.PacketsRcvd < e2.Counters.PacketsRcvd
 				}
 			}
 			return func(e1, e2 *Row) bool {
+				if e1.Counters.PacketsRcvd == e2.Counters.PacketsRcvd {
+					return e1.Attributes.String() > e2.Attributes.String()
+				}
 				return e1.Counters.PacketsRcvd > e2.Counters.PacketsRcvd
 			}
 		case types.DirectionOut:
 			if ascending {
 				return func(e1, e2 *Row) bool {
+					if e1.Counters.PacketsSent == e2.Counters.PacketsSent {
+						return e1.Attributes.String() < e2.Attributes.String()
+					}
 					return e1.Counters.PacketsSent < e2.Counters.PacketsSent
 				}
 			}
 			return func(e1, e2 *Row) bool {
+				if e1.Counters.PacketsSent == e2.Counters.PacketsSent {
+					return e1.Attributes.String() > e2.Attributes.String()
+				}
 				return e1.Counters.PacketsSent > e2.Counters.PacketsSent
 			}
 		}
@@ -129,38 +147,62 @@ func By(sort SortOrder, direction types.Direction, ascending bool) by {
 		case types.DirectionBoth, types.DirectionSum:
 			if ascending {
 				return func(e1, e2 *Row) bool {
+					if e1.Counters.BytesSent+e1.Counters.BytesRcvd == e2.Counters.BytesSent+e2.Counters.BytesRcvd {
+						return e1.Attributes.String() < e2.Attributes.String()
+					}
 					return e1.Counters.BytesSent+e1.Counters.BytesRcvd < e2.Counters.BytesSent+e2.Counters.BytesRcvd
 				}
 			}
 			return func(e1, e2 *Row) bool {
+				if e1.Counters.BytesSent+e1.Counters.BytesRcvd == e2.Counters.BytesSent+e2.Counters.BytesRcvd {
+					return e1.Attributes.String() > e2.Attributes.String()
+				}
 				return e1.Counters.BytesSent+e1.Counters.BytesRcvd > e2.Counters.BytesSent+e2.Counters.BytesRcvd
 			}
 		case types.DirectionIn:
 			if ascending {
 				return func(e1, e2 *Row) bool {
+					if e1.Counters.BytesRcvd == e2.Counters.BytesRcvd {
+						return e1.Attributes.String() < e2.Attributes.String()
+					}
 					return e1.Counters.BytesRcvd < e2.Counters.BytesRcvd
 				}
 			}
 			return func(e1, e2 *Row) bool {
+				if e1.Counters.BytesRcvd == e2.Counters.BytesRcvd {
+					return e1.Attributes.String() > e2.Attributes.String()
+				}
 				return e1.Counters.BytesRcvd > e2.Counters.BytesRcvd
 			}
 		case types.DirectionOut:
 			if ascending {
 				return func(e1, e2 *Row) bool {
+					if e1.Counters.BytesSent == e2.Counters.BytesSent {
+						return e1.Attributes.String() < e2.Attributes.String()
+					}
 					return e1.Counters.BytesSent < e2.Counters.BytesSent
 				}
 			}
 			return func(e1, e2 *Row) bool {
+				if e1.Counters.BytesSent == e2.Counters.BytesSent {
+					return e1.Attributes.String() > e2.Attributes.String()
+				}
 				return e1.Counters.BytesSent > e2.Counters.BytesSent
 			}
 		}
 	case SortTime:
 		if ascending {
 			return func(e1, e2 *Row) bool {
+				if e1.Labels.Timestamp.Equal(e2.Labels.Timestamp) {
+					return e1.Attributes.String() < e2.Attributes.String()
+				}
 				return e1.Labels.Timestamp.Before(e2.Labels.Timestamp)
 			}
 		}
 		return func(e1, e2 *Row) bool {
+			if e1.Labels.Timestamp.Equal(e2.Labels.Timestamp) {
+				return e1.Attributes.String() > e2.Attributes.String()
+			}
 			return e1.Labels.Timestamp.After(e2.Labels.Timestamp)
 		}
 	}


### PR DESCRIPTION
@els0r Simple solution / proposal: Whenever two flows have equal counters relevant / chosen for sorting we "sub-sort" them by their attributes, following the requested order. That way results are always deterministic without breaking anything. 