### PR TITLE
[bugfix] Fix race condition when closing mock captures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/els0r/goProbe
 require (
 	github.com/els0r/status v1.0.0
 	github.com/fako1024/httpc v1.0.14
-	github.com/fako1024/slimcap v0.0.0-20230608082455-e947914097f1
+	github.com/fako1024/slimcap v0.0.0-20230611191315-b410f996b186
 	github.com/gin-gonic/gin v1.9.1
 	github.com/json-iterator/go v1.1.12
 	github.com/spf13/cobra v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/els0r/goProbe
 require (
 	github.com/els0r/status v1.0.0
 	github.com/fako1024/httpc v1.0.14
-	github.com/fako1024/slimcap v0.0.0-20230526070625-9ca681cc73d5
+	github.com/fako1024/slimcap v0.0.0-20230608074003-9a0f7adbf569
 	github.com/gin-gonic/gin v1.9.1
 	github.com/json-iterator/go v1.1.12
 	github.com/spf13/cobra v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/els0r/goProbe
 require (
 	github.com/els0r/status v1.0.0
 	github.com/fako1024/httpc v1.0.14
-	github.com/fako1024/slimcap v0.0.0-20230608074003-9a0f7adbf569
+	github.com/fako1024/slimcap v0.0.0-20230608082455-e947914097f1
 	github.com/gin-gonic/gin v1.9.1
 	github.com/json-iterator/go v1.1.12
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fako1024/httpc v1.0.14 h1:1WDlT2p7tlfGBhkZXgG+VbIwFx5nVql2ht+yn5zMnmI=
 github.com/fako1024/httpc v1.0.14/go.mod h1:dqjklLvXS72dQ7sFxWi0A9te7JdzG2BhBXDe2OvjwvU=
-github.com/fako1024/slimcap v0.0.0-20230608074003-9a0f7adbf569 h1:fdEeYa2CCm2Tp3loO257KqlTULvF4sVhBKrxmfCwReM=
-github.com/fako1024/slimcap v0.0.0-20230608074003-9a0f7adbf569/go.mod h1:yux7ThjYmysyyk1YefBe3Eyzchp8dG+w5afA4Nje/dE=
+github.com/fako1024/slimcap v0.0.0-20230608082455-e947914097f1 h1:I1Eg766UZM9CidSmOBqF48KaSQa7JUBBf+Gku7vjVGc=
+github.com/fako1024/slimcap v0.0.0-20230608082455-e947914097f1/go.mod h1:yux7ThjYmysyyk1YefBe3Eyzchp8dG+w5afA4Nje/dE=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fako1024/httpc v1.0.14 h1:1WDlT2p7tlfGBhkZXgG+VbIwFx5nVql2ht+yn5zMnmI=
 github.com/fako1024/httpc v1.0.14/go.mod h1:dqjklLvXS72dQ7sFxWi0A9te7JdzG2BhBXDe2OvjwvU=
-github.com/fako1024/slimcap v0.0.0-20230526070625-9ca681cc73d5 h1:XshFPXeOwxi0IgvmGx4F4SHcRbf8A06Oun0sXcw2uXU=
-github.com/fako1024/slimcap v0.0.0-20230526070625-9ca681cc73d5/go.mod h1:yux7ThjYmysyyk1YefBe3Eyzchp8dG+w5afA4Nje/dE=
+github.com/fako1024/slimcap v0.0.0-20230608074003-9a0f7adbf569 h1:fdEeYa2CCm2Tp3loO257KqlTULvF4sVhBKrxmfCwReM=
+github.com/fako1024/slimcap v0.0.0-20230608074003-9a0f7adbf569/go.mod h1:yux7ThjYmysyyk1YefBe3Eyzchp8dG+w5afA4Nje/dE=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fako1024/httpc v1.0.14 h1:1WDlT2p7tlfGBhkZXgG+VbIwFx5nVql2ht+yn5zMnmI=
 github.com/fako1024/httpc v1.0.14/go.mod h1:dqjklLvXS72dQ7sFxWi0A9te7JdzG2BhBXDe2OvjwvU=
-github.com/fako1024/slimcap v0.0.0-20230608082455-e947914097f1 h1:I1Eg766UZM9CidSmOBqF48KaSQa7JUBBf+Gku7vjVGc=
-github.com/fako1024/slimcap v0.0.0-20230608082455-e947914097f1/go.mod h1:yux7ThjYmysyyk1YefBe3Eyzchp8dG+w5afA4Nje/dE=
+github.com/fako1024/slimcap v0.0.0-20230611191315-b410f996b186 h1:0M1qoyXcDEey1suM7kAIzyp15JPb5uZbh7jUWW7Ia7Q=
+github.com/fako1024/slimcap v0.0.0-20230611191315-b410f996b186/go.mod h1:yux7ThjYmysyyk1YefBe3Eyzchp8dG+w5afA4Nje/dE=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=

--- a/pkg/capture/capture_test.go
+++ b/pkg/capture/capture_test.go
@@ -71,7 +71,7 @@ func testConcurrentMethodAccess(t *testing.T, nIfaces, nIterations int) {
 	if err != nil {
 		panic(err)
 	}
-	defer require.Nil(t, os.RemoveAll(tempDir))
+	defer os.RemoveAll(tempDir)
 
 	// Build / initialize mock sources for all interfaces
 	testMockSrcs := make(testMockSrcs)
@@ -172,7 +172,8 @@ func TestMockPacketCapturePerformance(t *testing.T) {
 	for mockSrc.CanAddPackets() {
 		require.Nil(t, mockSrc.AddPacket(testPacket))
 	}
-	errChan := mockSrc.Run(time.Microsecond)
+	errChan, err := mockSrc.Run(time.Microsecond)
+	require.Nil(t, err)
 
 	runtime := 10 * time.Second
 	mockC.process(ctx)
@@ -256,7 +257,8 @@ func testDeadlockHighTraffic(t *testing.T) {
 	for mockSrc.CanAddPackets() {
 		require.Nil(t, mockSrc.AddPacket(testPacket))
 	}
-	errChan := mockSrc.Run(time.Microsecond)
+	errChan, err := mockSrc.Run(time.Microsecond)
+	require.Nil(t, err)
 
 	mockC.process(ctx)
 
@@ -321,5 +323,8 @@ func initMockSrc(t *testing.T, iface string) (*afring.MockSourceNoDrain, <-chan 
 		require.Nil(t, mockSrc.AddPacket(testPacket))
 	}
 
-	return mockSrc, mockSrc.Run(100 * time.Millisecond)
+	errChan, err := mockSrc.Run(100 * time.Millisecond)
+	require.Nil(t, err)
+
+	return mockSrc, errChan
 }

--- a/pkg/e2etest/e2e_test.go
+++ b/pkg/e2etest/e2e_test.go
@@ -69,7 +69,7 @@ func testStartStop(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	defer require.Nil(t, os.RemoveAll(tempDir))
+	defer os.RemoveAll(tempDir)
 
 	// We quit on encountering SIGUSR2 (instead of the ususal SIGTERM or SIGINT)
 	// to avoid killing the test
@@ -221,7 +221,7 @@ func testE2E(t *testing.T, datasets ...[]byte) {
 	if err != nil {
 		panic(err)
 	}
-	defer require.Nil(t, os.RemoveAll(tempDir))
+	defer os.RemoveAll(tempDir)
 
 	// Define mock interfaces
 	var mockIfaces mockIfaces

--- a/pkg/e2etest/e2e_test.go
+++ b/pkg/e2etest/e2e_test.go
@@ -56,6 +56,70 @@ var defaultCaptureConfig = config.CaptureConfig{
 
 var externalPCAPPath string
 
+func TestStartStop(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		testStartStop(t)
+	}
+}
+
+func testStartStop(t *testing.T) {
+
+	// Setup a temporary directory for the test DB
+	tempDir, err := os.MkdirTemp(os.TempDir(), "goprobe_e2e_startstop")
+	if err != nil {
+		panic(err)
+	}
+	defer require.Nil(t, os.RemoveAll(tempDir))
+
+	// We quit on encountering SIGUSR2 (instead of the ususal SIGTERM or SIGINT)
+	// to avoid killing the test
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGUSR2)
+	defer stop()
+
+	ifaces := config.Ifaces{
+		"mock1": defaultCaptureConfig,
+		"mock2": defaultCaptureConfig,
+	}
+
+	captureManager, err := capture.InitManager(ctx, &config.Config{
+		DB: config.DBConfig{
+			Path:        tempDir,
+			EncoderType: encoders.EncoderTypeLZ4.String(),
+			Permissions: goDB.DefaultPermissions,
+		},
+		Interfaces: ifaces,
+		Logging: config.LogConfig{
+			Destination: "logfmt",
+			Level:       "warn",
+		},
+	}, capture.WithSourceInitFn(func(c *capture.Capture) (slimcap.SourceZeroCopy, error) {
+		mockSrc, err := afring.NewMockSource(c.Iface(),
+			afring.CaptureLength(link.CaptureLengthMinimalIPv6Transport),
+			afring.Promiscuous(false),
+			afring.BufferSize(1024*1024, 4),
+		)
+		require.Nil(t, err)
+		return mockSrc, nil
+	}))
+	require.Nil(t, err)
+
+	// Wait until goProbe is done processing all packets, then kill it in the
+	// background via the SIGUSR2 signal
+	// Send the termination signal to goProbe
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGUSR2); err != nil {
+		panic(err)
+	}
+
+	// Wait for the interrupt signal
+	<-ctx.Done()
+
+	// Finish up
+	shutDownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	captureManager.Close(shutDownCtx)
+
+	cancel()
+}
+
 func TestE2EBasic(t *testing.T) {
 	pcapData, err := pcaps.ReadFile(filepath.Join(testDataPath, defaultPcapTestFile))
 	require.Nil(t, err)


### PR DESCRIPTION
Corresponding upstream changes: https://github.com/fako1024/slimcap/pull/49

In addition to these I've also added synchronization for the termination of the `process()` routine. Strictly speaking it might not be necessary but I wanted to make sure we don't run into some weird edge case when e.g. updating existing interfaces (I'm thinking about the old `process()` still consuming from the ring buffer the "new" `process()` has already started to consume from (after all it's probably the same underlying kernel memory are, so who knows what might happen).

Now, when a `Capture` closes, it's handle is closed and processing is terminated for sure.

Closes #126 