### PR TITLE
[feature] Add totals to gpctl status and print results of commands as table

### DIFF
--- a/cmd/gpctl/cmd/config.go
+++ b/cmd/gpctl/cmd/config.go
@@ -6,16 +6,16 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
-	"text/tabwriter"
 	"time"
 
 	"github.com/els0r/goProbe/cmd/goProbe/config"
 	"github.com/els0r/goProbe/cmd/gpctl/pkg/conf"
 	"github.com/els0r/goProbe/pkg/api/goprobe/client"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/xlab/tablewriter"
 )
 
 const (
@@ -85,18 +85,32 @@ func configEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
 	})
 
 	fmt.Println()
-	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', tabwriter.AlignRight)
 
-	fmt.Fprintln(tw, "\tiface\tpromisc\tring_buffer_block_size\tring_buffer_num_blocks\t")
+	bold := color.New(color.Bold, color.FgWhite)
+
+	table := tablewriter.CreateTable()
+	table.UTF8Box()
+	table.AddTitle(bold.Sprint("Interface Configuration"))
+
+	table.AddRow("", "", "ring buffer", "ring buffer")
+	table.AddRow("iface", "promisc", "block size", "num blocks")
+	table.AddSeparator()
+
 	for _, icfg := range allConfigs {
-		fmt.Fprintf(tw, "\t%s\t%t\t%d\t%d\t\n", icfg.iface,
+		table.AddRow(icfg.iface,
 			icfg.cfg.Promisc,
 			icfg.cfg.RingBuffer.BlockSize,
 			icfg.cfg.RingBuffer.NumBlocks,
 		)
 	}
-	tw.Flush()
-	fmt.Println()
+
+	// set alignment before rendering
+	table.SetAlign(tablewriter.AlignLeft, 1)
+	table.SetAlign(tablewriter.AlignLeft, 2)
+	table.SetAlign(tablewriter.AlignRight, 3)
+	table.SetAlign(tablewriter.AlignRight, 4)
+
+	fmt.Println(table.Render())
 
 	return nil
 }

--- a/cmd/gpctl/cmd/status.go
+++ b/cmd/gpctl/cmd/status.go
@@ -80,11 +80,11 @@ func statusEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
 	table.UTF8Box()
 	table.AddTitle(bold.Sprint("Interface Statuses"))
 
-	table.AddRow("", "total", "", "total", "", "")
+	table.AddRow("", "total", "", "total", "", "", "active")
 	table.AddRow("iface",
 		"received", "+ received",
 		"processed", "+ processed",
-		"dropped",
+		"dropped", "since",
 	)
 	table.AddSeparator()
 
@@ -108,6 +108,7 @@ func statusEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
 			formatting.Countable(ifaceStatus.ReceivedTotal), formatting.Countable(ifaceStatus.Received),
 			formatting.Countable(ifaceStatus.ProcessedTotal), formatting.Countable(ifaceStatus.Processed),
 			dropped,
+			time.Since(ifaceStatus.StartedAt).Round(time.Second).String(),
 		)
 	}
 

--- a/cmd/gpctl/cmd/status.go
+++ b/cmd/gpctl/cmd/status.go
@@ -129,15 +129,15 @@ func statusEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
 
 	fmt.Printf(`Runtime info:
 
-    Running since: %s (%s ago)
-    Last writeout: %s (%s ago)
+            Running since: %s (%s ago)
+  Last scheduled writeout: %s (%s ago)
 
 Totals:
 
     Packets
        Received: %s / + %s
       Processed: %s / + %s
-        Dropped: + %d
+        Dropped:      + %d
 
 `,
 		startedAt.Local().Format(types.DefaultTimeOutputFormat), time.Since(startedAt).Round(time.Second).String(),

--- a/cmd/gpctl/cmd/status.go
+++ b/cmd/gpctl/cmd/status.go
@@ -136,7 +136,7 @@ func statusEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
     Packets
        Received: %s / + %s
       Processed: %s / + %s
-        Dropped: %d
+        Dropped: + %d
 
 `, lastWriteoutStr, ago,
 		formatting.Countable(runtimeTotalReceived), formatting.Countable(totalReceived),

--- a/cmd/gpctl/cmd/status.go
+++ b/cmd/gpctl/cmd/status.go
@@ -7,16 +7,17 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/els0r/goProbe/cmd/gpctl/pkg/conf"
 	"github.com/els0r/goProbe/pkg/api/goprobe/client"
 	"github.com/els0r/goProbe/pkg/capture/capturetypes"
+	"github.com/els0r/goProbe/pkg/formatting"
 	"github.com/els0r/goProbe/pkg/types"
-	"github.com/els0r/status"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/xlab/tablewriter"
 )
 
 // statusCmd represents the stats command
@@ -36,37 +37,6 @@ func init() {
 	rootCmd.AddCommand(statusCmd)
 }
 
-const (
-	receivedCol = "RECEIVED"
-	deltaCol    = "+"
-	droppedCol  = "DROPPED"
-
-	colDistance = 4
-)
-
-func printHeader() {
-	fmt.Println(strings.Repeat(" ", 2+status.StatusLineIndent+8+1) +
-		receivedCol +
-		strings.Repeat(" ", colDistance) +
-		deltaCol +
-		strings.Repeat(" ", colDistance) +
-		droppedCol,
-	)
-}
-
-func printStats(stats capturetypes.CaptureStats) {
-	rcvdStr := fmt.Sprint(stats.ReceivedTotal)
-	deltaStr := fmt.Sprint(stats.Received)
-	droppedStr := fmt.Sprint(stats.Dropped)
-
-	status.Okf("%s%s%s%s%s", rcvdStr,
-		strings.Repeat(" ", len(receivedCol)+colDistance-len(rcvdStr)),
-		deltaStr,
-		strings.Repeat(" ", len(deltaCol)+colDistance-len(deltaStr)),
-		droppedStr,
-	)
-}
-
 func statusEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) error {
 	client := client.New(viper.GetString(conf.GoProbeServerAddr))
 
@@ -78,13 +48,12 @@ func statusEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
 	}
 
 	var (
-		runtimeTotalReceived        int64
-		totalReceived, totalDropped int64
-		totalActive, totalIfaces    int = 0, len(statuses)
+		runtimeTotalReceived, runtimeTotalProcessed int64
+		totalReceived, totalProcessed, totalDropped int64
+		totalActive, totalIfaces                    int = 0, len(statuses)
 	)
 
 	fmt.Println()
-	printHeader()
 
 	var allStatuses []struct {
 		iface  string
@@ -104,19 +73,53 @@ func statusEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
 		return allStatuses[i].iface < allStatuses[j].iface
 	})
 
-	for _, st := range allStatuses {
-		status.Line(st.iface)
+	bold := color.New(color.Bold, color.FgWhite)
+	boldRed := color.New(color.Bold, color.FgRed)
 
+	table := tablewriter.CreateTable()
+	table.UTF8Box()
+	table.AddTitle(bold.Sprint("Interface Statuses"))
+
+	table.AddRow("", "total", "", "total", "", "")
+	table.AddRow("iface",
+		"received", "+ received",
+		"processed", "+ processed",
+		"dropped",
+	)
+	table.AddSeparator()
+
+	for _, st := range allStatuses {
 		ifaceStatus := st.status
 
 		runtimeTotalReceived += int64(ifaceStatus.ReceivedTotal)
+		runtimeTotalProcessed += int64(ifaceStatus.ProcessedTotal)
 
+		totalProcessed += int64(ifaceStatus.Processed)
 		totalReceived += int64(ifaceStatus.Received)
 		totalDropped += int64(ifaceStatus.Dropped)
 		totalActive++
 
-		printStats(ifaceStatus)
+		dropped := fmt.Sprint(ifaceStatus.Dropped)
+		if ifaceStatus.Dropped > 0 {
+			dropped = boldRed.Sprint(ifaceStatus.Dropped)
+		}
+
+		table.AddRow(st.iface,
+			formatting.Countable(ifaceStatus.ReceivedTotal), formatting.Countable(ifaceStatus.Received),
+			formatting.Countable(ifaceStatus.ProcessedTotal), formatting.Countable(ifaceStatus.Processed),
+			dropped,
+		)
 	}
+
+	// set alignment before rendering
+	table.SetAlign(tablewriter.AlignLeft, 1)
+	table.SetAlign(tablewriter.AlignRight, 2)
+	table.SetAlign(tablewriter.AlignRight, 3)
+	table.SetAlign(tablewriter.AlignRight, 4)
+	table.SetAlign(tablewriter.AlignRight, 5)
+	table.SetAlign(tablewriter.AlignRight, 6)
+
+	fmt.Println(table.Render())
 
 	lastWriteoutStr := "-"
 	ago := "-"
@@ -127,17 +130,19 @@ func statusEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
 		ago = time.Since(tLocal).Round(time.Second).String()
 	}
 
-	fmt.Println()
 	fmt.Printf("%d/%d interfaces active\n\n", totalActive, totalIfaces)
 	fmt.Printf(`Totals:
     Last writeout: %s (%s ago)
     Packets
-      Received: %d (+%d)
-      Dropped:  %d
+       Received: %s / + %s
+      Processed: %s / + %s
+        Dropped: %d
 
 `, lastWriteoutStr, ago,
-		runtimeTotalReceived,
-		totalReceived, totalDropped)
+		formatting.Countable(runtimeTotalReceived), formatting.Countable(totalReceived),
+		formatting.Countable(runtimeTotalProcessed), formatting.Countable(totalProcessed),
+		totalDropped,
+	)
 
 	return nil
 }

--- a/cmd/gpctl/cmd/status.go
+++ b/cmd/gpctl/cmd/status.go
@@ -114,11 +114,9 @@ func statusEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
 
 	// set alignment before rendering
 	table.SetAlign(tablewriter.AlignLeft, 1)
-	table.SetAlign(tablewriter.AlignRight, 2)
-	table.SetAlign(tablewriter.AlignRight, 3)
-	table.SetAlign(tablewriter.AlignRight, 4)
-	table.SetAlign(tablewriter.AlignRight, 5)
-	table.SetAlign(tablewriter.AlignRight, 6)
+	for i := 2; i <= 6; i++ {
+		table.SetAlign(tablewriter.AlignRight, i)
+	}
 
 	fmt.Println(table.Render())
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/els0r/goProbe
 
+go 1.18
+
 require (
 	github.com/els0r/status v1.0.0
 	github.com/fako1024/httpc v1.0.15-0.20230527113611-da5628ef596d
@@ -74,4 +76,3 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
 
-go 1.18

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@ require (
 	github.com/els0r/status v1.0.0
 	github.com/fako1024/httpc v1.0.15-0.20230527113611-da5628ef596d
 	github.com/fako1024/slimcap v0.0.0-20230628065646-a567eb3289a5
+	github.com/fatih/color v1.15.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/json-iterator/go v1.1.12
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.3
+	github.com/xlab/tablewriter v0.0.0-20160610135559-80b567a11ad5
 	github.com/zeebo/xxh3 v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.41.1
 	go.opentelemetry.io/otel/trace v1.15.1
@@ -21,7 +23,6 @@ require (
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.15.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -283,6 +283,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/xlab/tablewriter v0.0.0-20160610135559-80b567a11ad5 h1:gmD7q6cCJfBbcuobWQe/KzLsd9Cd3amS1Mq5f3uU1qo=
+github.com/xlab/tablewriter v0.0.0-20160610135559-80b567a11ad5/go.mod h1:fVwOndYN3s5IaGlMucfgxwMhqwcaJtlGejBU6zX6Yxw=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/api/goprobe/api.go
+++ b/pkg/api/goprobe/api.go
@@ -8,13 +8,16 @@ import (
 )
 
 const (
+	// DefaultServerAddress is the default address of the goProbe server
 	DefaultServerAddress = "localhost:8145"
 )
 
 const (
+	// IfacesQueryParam is the query parameter to specify the interfaces to query
 	IfacesQueryParam = "ifaces"
 )
 
+// QueryRoute is the route to run a goquery query
 const QueryRoute = "/_query"
 
 type response struct {
@@ -22,26 +25,42 @@ type response struct {
 	Error      string `json:"error,omitempty"`
 }
 
+// StatusRoute is the route to query the current status
 const StatusRoute = "/status"
 
+// StatusResponse is the response to a status query
 type StatusResponse struct {
 	response
-	LastWriteout time.Time                            `json:"last_writeout"`
-	Statuses     map[string]capturetypes.CaptureStats `json:"statuses"`
+	// LastWriteout denotes the time when the last writeout was performed
+	LastWriteout time.Time `json:"last_writeout"`
+	// StartedAt denotes the time when the capture manager was initialized and
+	// started capturing
+	StartedAt time.Time `json:"started_at"`
+	// Statuses stores the statistics for each interface
+	Statuses capturetypes.InterfaceStats `json:"statuses"`
 }
 
+// ConfigRoute is the route to query/modify the current configuration
 const ConfigRoute = "/config"
 
+// ConfigResponse is the response to a config query
 type ConfigResponse struct {
 	response
+	// Ifaces stores the current configuration for each interface
 	Ifaces config.Ifaces `json:"ifaces"`
 }
 
+// ConfigUpdateResponse is the response to a config update
 type ConfigUpdateResponse struct {
 	response
-	Enabled  []string `json:"enabled"`
-	Updated  []string `json:"updated"`
+	// Enabled stores the interfaces that were enabled
+	Enabled []string `json:"enabled"`
+	// Updated stores the interfaces that were updated
+	Updated []string `json:"updated"`
+	// Disabled stores the interfaces that were disabled
 	Disabled []string `json:"disabled"`
 }
 
+// ConfigUpdateRequest is the payload to update the configuration of all
+// interfaces stored in it
 type ConfigUpdateRequest config.Ifaces

--- a/pkg/api/goprobe/client/status.go
+++ b/pkg/api/goprobe/client/status.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetInterfaceStatus returns the interface capture stats from the running goProbe instance
-func (c *Client) GetInterfaceStatus(ctx context.Context, ifaces ...string) (statuses map[string]capturetypes.CaptureStats, lastWriteout time.Time, err error) {
+func (c *Client) GetInterfaceStatus(ctx context.Context, ifaces ...string) (statuses map[string]capturetypes.CaptureStats, lastWriteout time.Time, startedAt time.Time, err error) {
 	var res = new(gpapi.StatusResponse)
 
 	url := c.NewURL(addIfaceToPath(gpapi.StatusRoute, ifaces...))
@@ -31,8 +31,8 @@ func (c *Client) GetInterfaceStatus(ctx context.Context, ifaces ...string) (stat
 		if res.Error != "" {
 			err = fmt.Errorf("%d: %s", res.StatusCode, res.Error)
 		}
-		return nil, lastWriteout, err
+		return nil, lastWriteout, startedAt, err
 	}
 
-	return res.Statuses, res.LastWriteout, nil
+	return res.Statuses, res.LastWriteout, res.StartedAt, nil
 }

--- a/pkg/api/goprobe/server/status.go
+++ b/pkg/api/goprobe/server/status.go
@@ -15,7 +15,7 @@ func (server *Server) getStatus(c *gin.Context) {
 
 	resp := &gpapi.StatusResponse{}
 	resp.StatusCode = http.StatusOK
-	resp.LastWriteout = server.captureManager.LastRotation()
+	resp.StartedAt, resp.LastWriteout = server.captureManager.GetTimestamps()
 
 	var err error
 	ifaces, err = url.QueryUnescape(ifaces)

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/els0r/goProbe/cmd/goProbe/config"
 	"github.com/els0r/goProbe/pkg/capture/capturetypes"
@@ -121,6 +122,9 @@ type Capture struct {
 
 	// WaitGroup tracking active processing
 	wgProc sync.WaitGroup
+
+	// startedAt tracks when the capture was started
+	startedAt time.Time
 }
 
 // newCapture creates a new Capture associated with the given iface.
@@ -153,6 +157,9 @@ func (c *Capture) run(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to initialize capture: %w", err)
 	}
+
+	// make sure to store when the capture started
+	c.startedAt = time.Now()
 
 	// Start up processing and error handling / logging in the
 	// background
@@ -288,6 +295,7 @@ func (c *Capture) status() (*capturetypes.CaptureStats, error) {
 	c.stats.ProcessedTotal += c.stats.Processed
 
 	res := capturetypes.CaptureStats{
+		StartedAt:      c.startedAt,
 		Received:       stats.PacketsReceived,
 		ReceivedTotal:  c.stats.ReceivedTotal,
 		Dropped:        stats.PacketsDropped,

--- a/pkg/capture/capture_manager.go
+++ b/pkg/capture/capture_manager.go
@@ -29,6 +29,7 @@ type Manager struct {
 	lastAppliedConfig config.Ifaces
 
 	lastRotation time.Time
+	startedAt    time.Time
 }
 
 // InitManager initializes a CaptureManager and the underlying writeout logic
@@ -59,6 +60,10 @@ func InitManager(ctx context.Context, config *config.Config, opts ...ManagerOpti
 	if err != nil {
 		return nil, err
 	}
+
+	// this is the first time the capture manager is started and is important to report program runtime
+	captureManager.startedAt = time.Now()
+
 	captureManager.ScheduleWriteouts(ctx, time.Duration(goDB.DBWriteInterval)*time.Second)
 
 	return captureManager, nil

--- a/pkg/capture/capturetypes/status.go
+++ b/pkg/capture/capturetypes/status.go
@@ -21,6 +21,9 @@ type TaggedAggFlowMap struct {
 	Iface string       `json:"iface"`
 }
 
+// InterfaceStats stores the statistics for each interface
+type InterfaceStats map[string]CaptureStats
+
 // CaptureStats stores the capture stores its statistics
 // TODO: Track errors and similar counters in metrics
 type CaptureStats struct {

--- a/pkg/capture/capturetypes/status.go
+++ b/pkg/capture/capturetypes/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/els0r/goProbe/pkg/types/hashmap"
 )
@@ -23,11 +24,18 @@ type TaggedAggFlowMap struct {
 // CaptureStats stores the capture stores its statistics
 // TODO: Track errors and similar counters in metrics
 type CaptureStats struct {
-	Received       int `json:"received"`
-	ReceivedTotal  int `json:"received_total"`
-	Processed      int `json:"processed"`
+	// StartedAt denotes the time when the capture was started
+	StartedAt time.Time `json:"started_at"`
+	// Received denotes the number of packets received
+	Received int `json:"received"`
+	// Received denotes the number of packets received since the capture was started
+	ReceivedTotal int `json:"received_total"`
+	// Processed denotes the number of packets processed by the capture
+	Processed int `json:"processed"`
+	// Processed denotes the number of packets processed since the capture was started
 	ProcessedTotal int `json:"processed_total"`
-	Dropped        int `json:"dropped"`
+	// Dropped denotes the number of packets dropped
+	Dropped int `json:"dropped"`
 }
 
 // AddStats is a convenience method to total capture stats. This is relevant in the scope of

--- a/pkg/formatting/format.go
+++ b/pkg/formatting/format.go
@@ -1,0 +1,75 @@
+package formatting
+
+import (
+	"fmt"
+	"time"
+)
+
+// Countable is a uint64 that can be printed in a human readable format
+type Countable uint64
+
+// String prints the Countable in a human readable format
+func (c Countable) String() string {
+	return Count(uint64(c))
+}
+
+// Sizeable is a number of bytes that can be printed in a human readable format
+type Sizeable uint64
+
+// String prints the Sizeable in a human readable format
+func (s Sizeable) String() string {
+	return Size(uint64(s))
+}
+
+// Count takes a number and prints it in a human readable format,
+// e.g. 1000 -> 1k, 1000000 -> 1M, 1000000000 -> 1G
+func Count(val uint64) string {
+	count := 0
+	var valF = float64(val)
+
+	units := []string{" ", "k", "M", "G", "T", "P", "E", "Z", "Y"}
+
+	for val >= 1000 {
+		val /= 1000
+		valF /= 1000.0
+		count++
+	}
+	if valF == 0 {
+		return fmt.Sprintf("%.2f %s", valF, units[count])
+	}
+
+	return fmt.Sprintf("%.2f %s", valF, units[count])
+}
+
+// Size prints out size in a human-readable format (e.g. 10 MB)
+func Size(size uint64) string {
+	count := 0
+	var sizeF = float64(size)
+
+	units := []string{" B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
+
+	for size > 1024 {
+		size /= 1024
+		sizeF /= 1024.0
+		count++
+	}
+	if sizeF == 0 {
+		return fmt.Sprintf("%.2f %s", sizeF, units[count])
+	}
+
+	return fmt.Sprintf("%.2f %s", sizeF, units[count])
+}
+
+// Duration prints out d in a human-readable duration format
+func Duration(d time.Duration) string {
+	if d/time.Hour != 0 {
+		return fmt.Sprintf("%dh%2dm", d/time.Hour, d%time.Hour/time.Minute)
+	}
+	if d/time.Minute != 0 {
+		return fmt.Sprintf("%dm%2ds", d/time.Minute, d%time.Minute/time.Second)
+	}
+	if d/time.Second != 0 {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return fmt.Sprintf("%dms", d/time.Millisecond)
+}

--- a/pkg/formatting/format_test.go
+++ b/pkg/formatting/format_test.go
@@ -1,0 +1,72 @@
+package formatting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountHumanized(t *testing.T) {
+	var tests = []struct {
+		input    uint64
+		expected string
+	}{
+		{0, "0.00  "},
+		{1, "1.00  "},
+		{100000, "100.00 k"},
+		{238327428, "238.33 M"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.expected, func(t *testing.T) {
+			actual := Count(test.input)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestSize(t *testing.T) {
+	var tests = []struct {
+		input    uint64
+		expected string
+	}{
+		{0, "0.00  B"},
+		{231, "231.00  B"},
+		{2338231, "2.23 MB"},
+		{28319384728, "26.37 GB"},
+		{2832828383338231, "2.52 PB"},
+		{2832828383338238231, "2.46 EB"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.expected, func(t *testing.T) {
+			actual := Size(test.input)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestDuration(t *testing.T) {
+	var tests = []struct {
+		input    time.Duration
+		expected string
+	}{
+		{0, "0ms"},
+		{1 * time.Millisecond, "1ms"},
+		{1 * time.Second, "1.0s"},
+		{1*time.Second + 232*time.Millisecond, "1.2s"},
+		{1*time.Minute + 3*time.Second, "1m 3s"},
+		{1*time.Hour + 3*time.Minute + 3*time.Second, "1h 3m"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.expected, func(t *testing.T) {
+			actual := Duration(test.input)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/pkg/results/TablePrinter.go
+++ b/pkg/results/TablePrinter.go
@@ -20,6 +20,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/els0r/goProbe/pkg/formatting"
 	"github.com/els0r/goProbe/pkg/goDB/protocols"
 	"github.com/els0r/goProbe/pkg/types"
 )
@@ -451,54 +452,17 @@ func NewTextFormatter() TextFormatter {
 
 // Size prints out size in a human-readable format (e.g. 10 MB)
 func (TextFormatter) Size(size uint64) string {
-	count := 0
-	var sizeF = float64(size)
-
-	units := []string{" B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
-
-	for size > 1024 {
-		size /= 1024
-		sizeF /= 1024.0
-		count++
-	}
-	if sizeF == 0 {
-		return fmt.Sprintf("%.2f %s", sizeF, units[count])
-	}
-
-	return fmt.Sprintf("%.2f %s", sizeF, units[count])
+	return formatting.Size(size)
 }
 
 // Duration prints out d in a human-readable duration format
 func (TextFormatter) Duration(d time.Duration) string {
-	if d/time.Hour != 0 {
-		return fmt.Sprintf("%dh%2dm", d/time.Hour, d%time.Hour/time.Minute)
-	}
-	if d/time.Minute != 0 {
-		return fmt.Sprintf("%dm%2ds", d/time.Minute, d%time.Minute/time.Second)
-	}
-	if d/time.Second != 0 {
-		return fmt.Sprintf("%.1fs", d.Seconds())
-	}
-	return fmt.Sprintf("%dms", d/time.Millisecond)
+	return formatting.Duration(d)
 }
 
 // Count prints val in concise human-readable form (e.g. 1 K instead of 1000)
 func (TextFormatter) Count(val uint64) string {
-	count := 0
-	var valF = float64(val)
-
-	units := []string{" ", "k", "M", "G", "T", "P", "E", "Z", "Y"}
-
-	for val >= 1000 {
-		val /= 1000
-		valF /= 1000.0
-		count++
-	}
-	if valF == 0 {
-		return fmt.Sprintf("%.2f %s", valF, units[count])
-	}
-
-	return fmt.Sprintf("%.2f %s", valF, units[count])
+	return formatting.Count(val)
 }
 
 // Float prints f rounded to two decimals


### PR DESCRIPTION
### Status

Now includes the runtime totals for received and processed. Looks as follows:
```

╭───────────────────────────────────────────────────────────────────╮
│                        Interface Statuses                         │
├───────┬──────────┬────────────┬───────────┬─────────────┬─────────┤
│       │    total │            │     total │             │         │
│ iface │ received │ + received │ processed │ + processed │ dropped │
├───────┼──────────┼────────────┼───────────┼─────────────┼─────────┤
│ eth0  │  58.38 k │   514.00   │   58.38 k │    513.00   │ 0       │
│ eth1  │   0.00   │     0.00   │    0.00   │      0.00   │ 0       │
╰───────┴──────────┴────────────┴───────────┴─────────────┴─────────╯

2/2 interfaces active

Totals:
    Last writeout: 2023-06-21 03:35:00 (54s ago)
    Packets
       Received: 58.38 k / + 514.00
      Processed: 58.38 k / + 513.00
        Dropped: 0

```

### Config

```

╭─────────────────────────────────────────────╮
│           Interface Configuration           │
├───────┬─────────┬─────────────┬─────────────┤
│       │         │ ring buffer │ ring buffer │
│ iface │ promisc │  block size │ num blocks  │
├───────┼─────────┼─────────────┼─────────────┤
│ eth0  │ true    │    10485760 │ 2           │
│ eth1  │ true    │    10485760 │ 2           │
╰───────┴─────────┴─────────────┴─────────────╯

```

Closes #134.