### PR TITLE
[feature] Support for logging to file

### DIFF
--- a/pkg/logging/init.go
+++ b/pkg/logging/init.go
@@ -3,6 +3,7 @@ package logging
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -25,42 +26,84 @@ const (
 	initKeyVersion = "version"
 )
 
-type Option func(*loggingConfig)
+type Option func(*loggingConfig) error
 
 // WithOutput sets the log output
 func WithOutput(w io.Writer) Option {
-	return func(lc *loggingConfig) {
+	return func(lc *loggingConfig) error {
 		lc.stdOutput = w
+		return nil
 	}
 }
 
 // WithErrorOutput sets the log output for level Error, Fatal and Panic. For the rest,
 // the default output os.Stdout or the output set by `WithOutput` is chosen
 func WithErrorOutput(w io.Writer) Option {
-	return func(lc *loggingConfig) {
+	return func(lc *loggingConfig) error {
 		lc.errsOutput = w
+		return nil
+	}
+}
+
+var (
+	emptyFilePathError = errors.New("empty filepath provided")
+)
+
+// WithFileOutput sets the log output to a file. The filepath can be one of the following:
+//
+// - stdout: logs will be written to os.Stdout
+// - stderr: logs will be written to os.Stderr
+// - devnull: logs will be discarded
+// - any other filepath: logs will be written to the file
+func WithFileOutput(filepath string) Option {
+	return func(lc *loggingConfig) error {
+		var output io.Writer
+		switch filepath {
+		case "stdout":
+			output = os.Stdout
+		case "stderr":
+			output = os.Stderr
+		case "devnull":
+			output = io.Discard
+		case "":
+			return emptyFilePathError
+		default:
+			f, err := os.OpenFile(filepath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+			if err != nil {
+				return fmt.Errorf("failed to open file: %w", err)
+			}
+			output = f
+		}
+		err := WithOutput(output)(lc)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
 }
 
 // WithCaller sets whether the calling source should be logged, since the operation is
 // computationally expensive
 func WithCaller(b bool) Option {
-	return func(lc *loggingConfig) {
+	return func(lc *loggingConfig) error {
 		lc.enableCaller = b
+		return nil
 	}
 }
 
 // WithName sets the application name as initial field present in all log messages
 func WithName(name string) Option {
-	return func(lc *loggingConfig) {
+	return func(lc *loggingConfig) error {
 		lc.initialAttr[initKeyName] = slog.String(initKeyName, name)
+		return nil
 	}
 }
 
 // WithVersion sets the application version as initial field present in all log messages
 func WithVersion(version string) Option {
-	return func(lc *loggingConfig) {
+	return func(lc *loggingConfig) error {
 		lc.initialAttr[initKeyVersion] = slog.String(initKeyVersion, version)
+		return nil
 	}
 }
 
@@ -122,7 +165,10 @@ func New(level slog.Level, encoding Encoding, opts ...Option) (*L, error) {
 		initialAttr: make(map[string]slog.Attr),
 	}
 	for _, opt := range opts {
-		opt(cfg)
+		err := opt(cfg)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	hopts := slog.HandlerOptions{

--- a/pkg/logging/init.go
+++ b/pkg/logging/init.go
@@ -74,11 +74,7 @@ func WithFileOutput(filepath string) Option {
 			}
 			output = f
 		}
-		err := WithOutput(output)(lc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return WithOutput(output)(lc)
 	}
 }
 

--- a/pkg/logging/init.go
+++ b/pkg/logging/init.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 
 	"golang.org/x/exp/slog"
@@ -49,21 +50,29 @@ var (
 	emptyFilePathError = errors.New("empty filepath provided")
 )
 
+const (
+	devnullOutput = "devnull"
+	stderrOutput  = "stderr"
+	stdoutOutput  = "stdout"
+)
+
 // WithFileOutput sets the log output to a file. The filepath can be one of the following:
 //
 // - stdout: logs will be written to os.Stdout
 // - stderr: logs will be written to os.Stderr
 // - devnull: logs will be discarded
 // - any other filepath: logs will be written to the file
+//
+// The special filepaths are case insensitive, e.g. DEVNULL works just as well
 func WithFileOutput(filepath string) Option {
 	return func(lc *loggingConfig) error {
 		var output io.Writer
-		switch filepath {
-		case "stdout":
+		switch strings.ToLower(filepath) { // ToLower will allow users to pass STDERR for example
+		case stdoutOutput:
 			output = os.Stdout
-		case "stderr":
+		case stderrOutput:
 			output = os.Stderr
-		case "devnull":
+		case devnullOutput:
 			output = io.Discard
 		case "":
 			return emptyFilePathError

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -38,6 +38,31 @@ func TestInitialization(t *testing.T) {
 	})
 }
 
+func TestFileOutputOption(t *testing.T) {
+	var tests = []struct {
+		in            string
+		expectedError error
+		clean         bool
+	}{
+		{"stdout", nil, false},
+		{"stderr", nil, false},
+		{"devnull", nil, false},
+		{"", emptyFilePathError, false},
+		{"tmpfile", nil, true},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			_, err := New(LevelDebug, EncodingLogfmt, WithFileOutput(test.in))
+			require.ErrorIs(t, test.expectedError, err)
+			if test.clean {
+				os.RemoveAll(test.in)
+			}
+		})
+	}
+}
+
 func TestBogusInput(t *testing.T) {
 	_, err := NewFromContext(context.Background(), 42, Encoding("00000000000llllllllll"))
 	require.NotNil(t, err)


### PR DESCRIPTION
Adds the `WithFileOutput` option to the logger as a convenience wrapper around `WithOutput`.