### PR TITLE
[feature] Log query metadata (args, stmt, summary) in goQuery if configured

### DIFF
--- a/cmd/goQuery/pkg/conf/conf.go
+++ b/cmd/goQuery/pkg/conf/conf.go
@@ -7,6 +7,7 @@ const (
 	QueryServerAddr      = serverKey + ".addr"
 	QueryTimeout         = queryKey + ".timeout"
 	QueryHostsResolution = queryKey + ".hosts-resolution"
+	QueryLog             = queryKey + ".log"
 
 	dbKey       = "db"
 	QueryDBPath = dbKey + ".path"

--- a/pkg/query/statement.go
+++ b/pkg/query/statement.go
@@ -14,7 +14,7 @@ type Statement struct {
 	// Ifaces holds hte list of all interfaces that should be queried
 	Ifaces []string `json:"ifaces"`
 
-	LabelSelector types.LabelSelector `json:"-"`
+	LabelSelector types.LabelSelector `json:"label_selector,omitempty"`
 
 	// needed for feedback to user
 	QueryType string `json:"query_type"`
@@ -40,10 +40,10 @@ type Statement struct {
 	Caller string `json:"caller,omitempty"` // who called the query
 
 	// resolution parameters (probably part of table printer)
-	DNSResolution DNSResolution
+	DNSResolution DNSResolution `json:"dns_resolution,omitempty"`
 
 	// file system
-	MaxMemPct int  `json:"-"`
+	MaxMemPct int  `json:"max_mem_pct,omitempty"`
 	LowMem    bool `json:"low_mem,omitempty"`
 }
 

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -134,7 +134,7 @@ func (hs HostsStatuses) Print(w io.Writer) {
 // Timinigs summarizes query runtimes
 type Timings struct {
 	QueryStart         time.Time     `json:"query_start"`
-	QueryDuration      time.Duration `json:"query_duration"`
+	QueryDuration      time.Duration `json:"query_duration_ns"`
 	ResolutionDuration time.Duration `json:"resolution,omitempty"`
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -18,10 +18,10 @@ const (
 const DefaultTimeOutputFormat = "2006-01-02 15:04:05"
 
 type LabelSelector struct {
-	Timestamp bool
-	Iface     bool
-	Hostname  bool
-	HostID    bool
+	Timestamp bool `json:"timestamp,omitempty"`
+	Iface     bool `json:"iface,omitempty"`
+	Hostname  bool `json:"hostname,omitempty"`
+	HostID    bool `json:"host_id,omitempty"`
 }
 
 type Width = int


### PR DESCRIPTION
Will log in three stages:

* query preparation: args
* query running: stmt
* query finish: summary

Depends on https://github.com/els0r/goProbe/pull/155 to build. Closes #17 

Example:
```
{
  "ts": "2023-08-02T21:46:46.568757798+02:00",
  "level": "info",
  "msg": "preparing query",
  "args": {
    "query": "iface",
    "ifaces": "any",
    "first": "-9000d",
    "last": "Wed Aug  2 21:46:46 2023",
    "format": "txt",
    "sort_by": "bytes",
    "num_results": 1000,
    "dns_resolution": {
      "enabled": false,
      "timeout": 1000000000,
      "max_rows": 25
    },
    "max_mem_pct": 60,
    "caller": "./goQuery"
  }
}
{
  "ts": "2023-08-02T21:46:46.574921923+02:00",
  "level": "info",
  "msg": "running query",
  "stmt": {
    "ifaces": null,
    "label_selector": {
      "iface": true
    },
    "query_type": "iface",
    "direction": "bi-directional",
    "from": 913405606,
    "to": 1691005606,
    "format": "txt",
    "limit": 1000,
    "sort_by": "bytes",
    "caller": "./goQuery",
    "dns_resolution": {
      "enabled": false,
      "timeout": 1000000000,
      "max_rows": 25
    },
    "max_mem_pct": 60
  }
}
{
  "ts": "2023-08-02T21:46:46.620758048+02:00",
  "level": "info",
  "msg": "query finished",
  "summary": {
    "interfaces": [
      "eth0",
      "eth1"
    ],
    "time_first": "2023-04-07T02:20:00+02:00",
    "time_last": "2023-06-29T00:10:00+02:00",
    "totals": {
      "br": 2448097479,
      "bs": 417739731,
      "pr": 1774839,
      "ps": 964525
    },
    "timings": {
      "query_start": "2023-08-02T21:46:46.577075548+02:00",
      "query_duration": 37998834
    },
    "hits": {
      "displayed": 2,
      "total": 2
    }
  }
}
```
