### PR TITLE
[bugfix] Aggregate IPv4 and IPv6 in queries without IP attributes

### DIFF
--- a/cmd/goConvert/goConvert.go
+++ b/cmd/goConvert/goConvert.go
@@ -410,9 +410,9 @@ func main() {
 
 		// insert the key-value pair into the correct flow map
 		if rowKey.IsIPv4() {
-			flowMaps[iface][ts].V4Map.Set(rowKey.Key(), rowVal)
+			flowMaps[iface][ts].PrimaryMap.Set(rowKey.Key(), rowVal)
 		} else {
-			flowMaps[iface][ts].V6Map.Set(rowKey.Key(), rowVal)
+			flowMaps[iface][ts].SecondaryMap.Set(rowKey.Key(), rowVal)
 		}
 		linesRead++
 	}

--- a/pkg/goDB/db_writer_test.go
+++ b/pkg/goDB/db_writer_test.go
@@ -30,7 +30,7 @@ func TestPanicDuringWrite(t *testing.T) {
 
 	// Add a single item that will trigger a panic later
 	testMap := hashmap.NewAggFlowMap()
-	testMap.V4Map.Set([]byte{0x0}, hashmap.Val{})
+	testMap.PrimaryMap.Set([]byte{0x0}, hashmap.Val{})
 
 	t.Run("Write", func(t *testing.T) {
 		require.Panics(t, func() {

--- a/pkg/goDB/godb_test.go
+++ b/pkg/goDB/godb_test.go
@@ -146,18 +146,18 @@ func populateTestDir(t *testing.T, basePath, iface string, timestamp time.Time) 
 
 func generateFlows() *hashmap.AggFlowMap {
 	m := hashmap.AggFlowMap{
-		V4Map: hashmap.New(),
-		V6Map: hashmap.New(),
+		PrimaryMap:   hashmap.New(),
+		SecondaryMap: hashmap.New(),
 	}
 
 	for i := byte(0); i < testNv4; i++ {
-		m.V4Map.Set(types.NewV4KeyStatic(
+		m.PrimaryMap.Set(types.NewV4KeyStatic(
 			[4]byte{i, i, i, i},
 			[4]byte{i, i, i, i},
 			[]byte{i, i}, i), types.Counters{BytesRcvd: uint64(i), BytesSent: 0, PacketsRcvd: uint64(i), PacketsSent: 0})
 	}
 	for i := byte(0); i < testNv6; i++ {
-		m.V6Map.Set(types.NewV6KeyStatic(
+		m.SecondaryMap.Set(types.NewV6KeyStatic(
 			[16]byte{i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i},
 			[16]byte{i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i},
 			[]byte{i, i}, i), types.Counters{BytesRcvd: 0, BytesSent: uint64(i), PacketsRcvd: 0, PacketsSent: uint64(i)})
@@ -217,8 +217,8 @@ func testWorkload(t *testing.T, c testCase, dryRun bool) {
 			// Perform sanity checks on aggregated data
 			require.Equal(t, int(c.nExpectedWorkloads), len(mapChan))
 			for aggMap := range mapChan {
-				require.Equal(t, testNv4, aggMap.V4Map.Len())
-				require.Equal(t, testNv6, aggMap.V6Map.Len())
+				require.Equal(t, testNv4, aggMap.PrimaryMap.Len())
+				require.Equal(t, testNv6, aggMap.SecondaryMap.Len())
 			}
 		}
 	}

--- a/pkg/types/hashmap/aggregate.go
+++ b/pkg/types/hashmap/aggregate.go
@@ -33,16 +33,16 @@ func New(n ...int) *Map {
 // AggFlowMap stores all flows where the source port from the FlowLog has been aggregated
 // Just a convenient alias for the map type itself
 type AggFlowMap struct {
-	V4Map *Map
-	V6Map *Map
+	PrimaryMap   *Map
+	SecondaryMap *Map
 }
 
 // NewAggFlowMap instantiates a new NewAggFlowMap with an underlying
 // hashmap for both IPv4 and IPv6 entries
 func NewAggFlowMap(n ...int) *AggFlowMap {
 	return &AggFlowMap{
-		V4Map: New(n...),
-		V6Map: New(n...),
+		PrimaryMap:   New(n...),
+		SecondaryMap: New(n...),
 	}
 }
 
@@ -100,8 +100,8 @@ func (n NamedAggFlowMapWithMetadata) ClearFast() {
 func NewAggFlowMapWithMetadata(n ...int) AggFlowMapWithMetadata {
 	return AggFlowMapWithMetadata{
 		AggFlowMap: &AggFlowMap{
-			V4Map: New(n...),
-			V6Map: New(n...),
+			PrimaryMap:   New(n...),
+			SecondaryMap: New(n...),
 		},
 	}
 }
@@ -116,19 +116,19 @@ func (a AggFlowMapWithMetadata) IsNil() bool {
 
 // IsNil returns if an AggFlowMap is nil (used e.g. in cases of error)
 func (a AggFlowMap) IsNil() bool {
-	return a.V4Map == nil && a.V6Map == nil
+	return a.PrimaryMap == nil && a.SecondaryMap == nil
 }
 
 // Len returns the number of valents in the map
 func (a AggFlowMap) Len() int {
-	return a.V4Map.count + a.V6Map.count
+	return a.PrimaryMap.count + a.SecondaryMap.count
 }
 
 // Iter provides a map Iter to allow traversal of both underlying maps (IPv4 and IPv6)
 func (a AggFlowMap) Iter() *MetaIter {
 	return &MetaIter{
-		Iter:   a.V4Map.Iter(),
-		v6Iter: a.V6Map.Iter(),
+		Iter:   a.PrimaryMap.Iter(),
+		v6Iter: a.SecondaryMap.Iter(),
 	}
 }
 
@@ -138,35 +138,35 @@ func (a AggFlowMap) Iter() *MetaIter {
 // it avoids intermediate allocation of a value type valent in case of an update
 func (a AggFlowMap) SetOrUpdate(key Key, isIPv4 bool, eA, eB, eC, eD uint64) {
 	if isIPv4 {
-		a.V4Map.SetOrUpdate(key, eA, eB, eC, eD)
+		a.PrimaryMap.SetOrUpdate(key, eA, eB, eC, eD)
 	} else {
-		a.V6Map.SetOrUpdate(key, eA, eB, eC, eD)
+		a.SecondaryMap.SetOrUpdate(key, eA, eB, eC, eD)
 	}
 }
 
 // Merge allows to incorporate the content of a map b into an existing map a (providing
 // additional in-place counter updates).
 func (a AggFlowMap) Merge(b AggFlowMap, totals *Val) {
-	a.V4Map.Merge(b.V4Map, totals)
-	a.V6Map.Merge(b.V6Map, totals)
+	a.PrimaryMap.Merge(b.PrimaryMap, totals)
+	a.SecondaryMap.Merge(b.SecondaryMap, totals)
 }
 
 // Merge allows to incorporate the content of a map b into an existing map a (providing
 // additional in-place counter updates).
 func (a AggFlowMapWithMetadata) Merge(b AggFlowMapWithMetadata, totals *Val) {
-	a.V4Map.Merge(b.V4Map, totals)
-	a.V6Map.Merge(b.V6Map, totals)
+	a.PrimaryMap.Merge(b.PrimaryMap, totals)
+	a.SecondaryMap.Merge(b.SecondaryMap, totals)
 }
 
 // Clear frees as many resources as possible by making them eligible for GC
 func (a AggFlowMap) Clear() {
-	a.V4Map.Clear()
-	a.V6Map.Clear()
+	a.PrimaryMap.Clear()
+	a.SecondaryMap.Clear()
 }
 
 // ClearFast nils all main resources, making them eligible for GC (but
 // probably not as effectively as Clear())
 func (a AggFlowMap) ClearFast() {
-	a.V4Map.ClearFast()
-	a.V6Map.ClearFast()
+	a.PrimaryMap.ClearFast()
+	a.SecondaryMap.ClearFast()
 }

--- a/pkg/types/hashmap/hashmap_test.go
+++ b/pkg/types/hashmap/hashmap_test.go
@@ -101,8 +101,8 @@ func TestAggFlowMapFlatten(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		temp := make([]byte, 8)
 		binary.BigEndian.PutUint64(temp, uint64(i))
-		testMap.V4Map.Set(temp, types.Counters{BytesRcvd: uint64(i), BytesSent: 0, PacketsRcvd: 0, PacketsSent: 0})
-		testMap.V6Map.Set(temp, types.Counters{BytesRcvd: uint64(i), BytesSent: 0, PacketsRcvd: 0, PacketsSent: 0})
+		testMap.PrimaryMap.Set(temp, types.Counters{BytesRcvd: uint64(i), BytesSent: 0, PacketsRcvd: 0, PacketsSent: 0})
+		testMap.SecondaryMap.Set(temp, types.Counters{BytesRcvd: uint64(i), BytesSent: 0, PacketsRcvd: 0, PacketsSent: 0})
 		var count int
 		for it := testMap.Iter(); it.Next(); {
 			count++
@@ -110,9 +110,9 @@ func TestAggFlowMapFlatten(t *testing.T) {
 		require.Equal(t, 2*(i+1), testMap.Len())
 		require.Equal(t, testMap.Len(), count)
 
-		v4List, v6List := testMap.Flatten()
-		require.Equal(t, i+1, len(v4List))
-		require.Equal(t, i+1, len(v6List))
+		primaryList, secondaryList := testMap.Flatten()
+		require.Equal(t, i+1, len(primaryList))
+		require.Equal(t, i+1, len(secondaryList))
 	}
 }
 

--- a/pkg/types/hashmap/list.go
+++ b/pkg/types/hashmap/list.go
@@ -17,18 +17,18 @@ type Item struct {
 type List []Item
 
 // Flatten converts a flow map to a flat table / list
-func (a *AggFlowMap) Flatten() (v4List List, v6List List) {
+func (a *AggFlowMap) Flatten() (primaryList List, secondaryList List) {
 	if a == nil {
 		return
 	}
 
-	v4List, v6List = make(List, a.V4Map.Len()), make(List, a.V6Map.Len())
+	primaryList, secondaryList = make(List, a.PrimaryMap.Len()), make(List, a.SecondaryMap.Len())
 
-	for j, it := 0, a.V4Map.Iter(); it.Next(); j++ {
-		v4List[j] = Item{it.Key(), it.Val()}
+	for j, it := 0, a.PrimaryMap.Iter(); it.Next(); j++ {
+		primaryList[j] = Item{it.Key(), it.Val()}
 	}
-	for j, it := 0, a.V6Map.Iter(); it.Next(); j++ {
-		v6List[j] = Item{it.Key(), it.Val()}
+	for j, it := 0, a.SecondaryMap.Iter(); it.Next(); j++ {
+		secondaryList[j] = Item{it.Key(), it.Val()}
 	}
 
 	return


### PR DESCRIPTION
This was even easier than anticipated (it would have been one line of code if it weren't for the fact that we _still_ want to support having IPv4 / IPv6 conditionals even if the attributes don't include any IPs).

Relevant commit is b821cd65b2f9b984bde686c419f30539e2f9d2b8 , the rest is cosmetics.

Output now:
```
goQuery -d /tmp/db_out2  -f "2006-03-01T00:00:00Z" list 

    iface    packets     traffic      flows                   from                     to
    -----    -------     -------      -----                   ----                     --
     eth0    19.39 G    19.55 TB    50.28 M    2016-02-29 23:17:00    2020-04-10 10:18:12
                                                                                         
    Total    19.39 G    19.55 TB    50.28 M

goQuery -d /tmp/db_out2  -f "2006-03-01T00:00:00Z" -i eth0 iface

           packets  packets             bytes     bytes        
    iface       in      out       %        in       out       %
     eth0  10.64 G   8.75 G  100.00  15.67 TB   3.88 TB  100.00
                                                               
           10.64 G   8.75 G          15.67 TB   3.88 TB        
                                                       
  Totals:           19.39 G                    19.55 TB

goQuery -d /tmp/db_out2  -f "2006-03-01T00:00:00Z" -i eth0 -c "dport eq 443" dport

           packets  packets            bytes      bytes        
    dport       in      out       %       in        out       %
      443   1.36 G   1.40 G  100.00  2.39 TB  405.02 GB  100.00
                                                               
            1.36 G   1.40 G          2.39 TB  405.02 GB        
                                                       
  Totals:            2.76 G                     2.79 TB
```

Looks consistent to me (also no duplication anymore for `dport` query)...

Closes #146 