### PR TITLE
[bugfix] Add option to disable scheduled writeouts on CaptureManager and disable for E2E tests

### DIFF
--- a/pkg/capture/capture_manager.go
+++ b/pkg/capture/capture_manager.go
@@ -30,6 +30,8 @@ type Manager struct {
 
 	lastRotation time.Time
 	startedAt    time.Time
+
+	skipWriteoutSchedule bool
 }
 
 // InitManager initializes a CaptureManager and the underlying writeout logic
@@ -64,7 +66,9 @@ func InitManager(ctx context.Context, config *config.Config, opts ...ManagerOpti
 	// this is the first time the capture manager is started and is important to report program runtime
 	captureManager.startedAt = time.Now()
 
-	captureManager.ScheduleWriteouts(ctx, time.Duration(goDB.DBWriteInterval)*time.Second)
+	if !captureManager.skipWriteoutSchedule {
+		captureManager.ScheduleWriteouts(ctx, time.Duration(goDB.DBWriteInterval)*time.Second)
+	}
 
 	return captureManager, nil
 }
@@ -163,6 +167,13 @@ type ManagerOption func(cm *Manager)
 func WithSourceInitFn(fn sourceInitFn) ManagerOption {
 	return func(cm *Manager) {
 		cm.sourceInitFn = fn
+	}
+}
+
+// WithSkipWriteoutSchedule disables scheduled writeouts
+func WithSkipWriteoutSchedule(skip bool) ManagerOption {
+	return func(cm *Manager) {
+		cm.skipWriteoutSchedule = skip
 	}
 }
 

--- a/pkg/e2etest/e2e_test.go
+++ b/pkg/e2etest/e2e_test.go
@@ -102,7 +102,7 @@ func testStartStop(t *testing.T) {
 		)
 		require.Nil(t, err)
 		return mockSrc, nil
-	}))
+	}), capture.WithSkipWriteoutSchedule(true))
 	require.Nil(t, err)
 
 	// Wait until goProbe is done processing all packets, then kill it in the
@@ -294,7 +294,10 @@ func runGoProbe(t *testing.T, testDir string, sourceInitFn func() (mockIfaces, f
 		},
 		Interfaces: ifaceConfigs,
 		Logging:    config.LogConfig{},
-	}, capture.WithSourceInitFn(initFn))
+	},
+		capture.WithSourceInitFn(initFn),
+		capture.WithSkipWriteoutSchedule(true),
+	)
 	require.Nil(t, err)
 
 	// Wait until goProbe is done processing all packets, then kill it in the


### PR DESCRIPTION
This will prevent the E2E test from automatically writing to the DB (on top of the manual writeout once all mock data has been processed), thus (hopefully) avoiding any race conditions / results mismatches.

Closes #157 