### PR TITLE
[bugfix] Switch all packet stats / counters to uint64

### DIFF
--- a/cmd/legacy/main.go
+++ b/cmd/legacy/main.go
@@ -231,7 +231,7 @@ func (c converter) convertDir(w work, dryRun bool) error {
 		bulkWorkload = append(bulkWorkload, goDB.BulkWorkload{
 			FlowMap: block.data,
 			CaptureMeta: goDB.CaptureMetadata{
-				PacketsDropped: blockMetadata.PcapPacketsDropped + blockMetadata.PcapPacketsIfDropped,
+				PacketsDropped: ensureUnsigned(blockMetadata.PcapPacketsDropped) + ensureUnsigned(blockMetadata.PcapPacketsIfDropped),
 			},
 			Timestamp: block.ts,
 		})
@@ -251,4 +251,11 @@ func newKeyFromNetIPAddr(sip, dip netip.Addr, dport []byte, proto byte, isIPv4 b
 		return types.NewV4KeyStatic(sip.As4(), dip.As4(), dport, proto)
 	}
 	return types.NewV6KeyStatic(sip.As16(), dip.As16(), dport, proto)
+}
+
+func ensureUnsigned(in int) uint64 {
+	if in <= 0 {
+		return 0
+	}
+	return uint64(in)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/els0r/status v1.0.0
 	github.com/fako1024/httpc v1.0.15-0.20230527113611-da5628ef596d
-	github.com/fako1024/slimcap v0.0.0-20230628065646-a567eb3289a5
+	github.com/fako1024/slimcap v0.0.0-20230804105950-d6cd61048020
 	github.com/fatih/color v1.15.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/json-iterator/go v1.1.12
@@ -75,4 +75,3 @@ require (
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
-

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/fako1024/httpc v1.0.15-0.20230527113611-da5628ef596d h1:F3C5kQisGHZJi
 github.com/fako1024/httpc v1.0.15-0.20230527113611-da5628ef596d/go.mod h1:dqjklLvXS72dQ7sFxWi0A9te7JdzG2BhBXDe2OvjwvU=
 github.com/fako1024/slimcap v0.0.0-20230628065646-a567eb3289a5 h1:GCMNKHnSr9gs2DTVmgBuhmL3MkCVx2gyzoJES1HBxCs=
 github.com/fako1024/slimcap v0.0.0-20230628065646-a567eb3289a5/go.mod h1:yux7ThjYmysyyk1YefBe3Eyzchp8dG+w5afA4Nje/dE=
+github.com/fako1024/slimcap v0.0.0-20230804105950-d6cd61048020 h1:mCwDAcPPNO1vMftozGUukvTglbqFPQhapq7GyJFvqyc=
+github.com/fako1024/slimcap v0.0.0-20230804105950-d6cd61048020/go.mod h1:yux7ThjYmysyyk1YefBe3Eyzchp8dG+w5afA4Nje/dE=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=

--- a/pkg/capture/capturetypes/status.go
+++ b/pkg/capture/capturetypes/status.go
@@ -30,15 +30,15 @@ type CaptureStats struct {
 	// StartedAt denotes the time when the capture was started
 	StartedAt time.Time `json:"started_at"`
 	// Received denotes the number of packets received
-	Received int `json:"received"`
+	Received uint64 `json:"received"`
 	// Received denotes the number of packets received since the capture was started
-	ReceivedTotal int `json:"received_total"`
+	ReceivedTotal uint64 `json:"received_total"`
 	// Processed denotes the number of packets processed by the capture
-	Processed int `json:"processed"`
+	Processed uint64 `json:"processed"`
 	// Processed denotes the number of packets processed since the capture was started
-	ProcessedTotal int `json:"processed_total"`
+	ProcessedTotal uint64 `json:"processed_total"`
 	// Dropped denotes the number of packets dropped
-	Dropped int `json:"dropped"`
+	Dropped uint64 `json:"dropped"`
 }
 
 // AddStats is a convenience method to total capture stats. This is relevant in the scope of

--- a/pkg/e2etest/e2e_test.go
+++ b/pkg/e2etest/e2e_test.go
@@ -246,7 +246,7 @@ func testE2E(t *testing.T, datasets ...[]byte) {
 	resReference := mockIfaces.BuildResults(t, tempDir, resGoQuery)
 
 	// Counter consistency checks
-	require.Equal(t, mockIfaces.NProcessed(), int(resGoQuery.Summary.Totals.PacketsRcvd))
+	require.Equal(t, mockIfaces.NProcessed(), resGoQuery.Summary.Totals.PacketsRcvd)
 	require.Equal(t, mockIfaces.NProcessed(), mockIfaces.NRead()-mockIfaces.NErr())
 
 	// Summary consistency check (do not fail yet to show details in the next check)

--- a/pkg/e2etest/types.go
+++ b/pkg/e2etest/types.go
@@ -21,9 +21,9 @@ import (
 )
 
 type mockTracking struct {
-	nRead      int
-	nProcessed int
-	nErr       int
+	nRead      uint64
+	nProcessed uint64
+	nErr       uint64
 
 	done chan struct{}
 }
@@ -63,7 +63,7 @@ func (m mockIfaces) WaitUntilDoneReading() {
 	wg.Wait()
 }
 
-func (m mockIfaces) NRead() (res int) {
+func (m mockIfaces) NRead() (res uint64) {
 	for _, v := range m {
 		v.RLock()
 		res += v.tracking.nRead
@@ -72,7 +72,7 @@ func (m mockIfaces) NRead() (res int) {
 	return
 }
 
-func (m mockIfaces) NProcessed() (res int) {
+func (m mockIfaces) NProcessed() (res uint64) {
 	for _, v := range m {
 		v.RLock()
 		res += v.tracking.nProcessed
@@ -81,7 +81,7 @@ func (m mockIfaces) NProcessed() (res int) {
 	return
 }
 
-func (m mockIfaces) NErr() (res int) {
+func (m mockIfaces) NErr() (res uint64) {
 	for _, v := range m {
 		v.RLock()
 		res += v.tracking.nErr
@@ -153,7 +153,7 @@ func (m mockIfaces) KillGoProbeOnceDone(cm *capture.Manager) {
 
 		// Grab the number of overall received / processed packets in all captures and
 		// wait until they match the number of read packets
-		var nProcessed int
+		var nProcessed uint64
 		for _, st := range cm.Status(ctx) {
 			nProcessed += st.ProcessedTotal
 		}

--- a/pkg/goDB/metadata.go
+++ b/pkg/goDB/metadata.go
@@ -12,7 +12,7 @@ import (
 // TODO: check with fako1024 if this can be removed already or if this is
 // post-v4-release
 type CaptureMetadata struct {
-	PacketsDropped int
+	PacketsDropped uint64
 }
 
 // InterfaceMetadata describes the time range for which data is available, how many flows

--- a/pkg/goDB/storage/gpfile/gpdir.go
+++ b/pkg/goDB/storage/gpfile/gpdir.go
@@ -42,7 +42,7 @@ var (
 type TrafficMetadata struct {
 	NumV4Entries uint64 `json:"num_v4_entries"`
 	NumV6Entries uint64 `json:"num_v6_entries"`
-	NumDrops     int    `json:"num_drops"`
+	NumDrops     uint64 `json:"num_drops"`
 }
 
 type Stats struct {
@@ -91,7 +91,7 @@ type Metadata struct {
 	BlockTraffic  []TrafficMetadata
 
 	Stats
-	Version int
+	Version uint64
 }
 
 // newMetadata initializes a new Metadata set (internal / serialization use only)
@@ -263,15 +263,15 @@ func (d *GPDir) Unmarshal(r ReadWriteSeekCloser) error {
 
 	d.Metadata = newMetadata()
 
-	d.Metadata.Version = int(binary.BigEndian.Uint64(data[0:8]))            // Get header version
-	nBlocks := int(binary.BigEndian.Uint64(data[8:16]))                     // Get flat nummber of blocks
-	d.Metadata.Traffic.NumV4Entries = binary.BigEndian.Uint64(data[16:24])  // Get global number of IPv4 flows
-	d.Metadata.Traffic.NumV6Entries = binary.BigEndian.Uint64(data[24:32])  // Get global number of IPv6 flows
-	d.Metadata.Traffic.NumDrops = int(binary.BigEndian.Uint64(data[32:40])) // Get global number of dropped packets
-	d.Metadata.Counts.BytesRcvd = binary.BigEndian.Uint64(data[40:48])      // Get global Counters (BytesRcvd)
-	d.Metadata.Counts.BytesSent = binary.BigEndian.Uint64(data[48:56])      // Get global Counters (BytesSent)
-	d.Metadata.Counts.PacketsRcvd = binary.BigEndian.Uint64(data[56:64])    // Get global Counters (PacketsRcvd)
-	d.Metadata.Counts.PacketsSent = binary.BigEndian.Uint64(data[64:72])    // Get global Counters (PacketsSent)
+	d.Metadata.Version = binary.BigEndian.Uint64(data[0:8])                // Get header version
+	nBlocks := int(binary.BigEndian.Uint64(data[8:16]))                    // Get flat nummber of blocks
+	d.Metadata.Traffic.NumV4Entries = binary.BigEndian.Uint64(data[16:24]) // Get global number of IPv4 flows
+	d.Metadata.Traffic.NumV6Entries = binary.BigEndian.Uint64(data[24:32]) // Get global number of IPv6 flows
+	d.Metadata.Traffic.NumDrops = binary.BigEndian.Uint64(data[32:40])     // Get global number of dropped packets
+	d.Metadata.Counts.BytesRcvd = binary.BigEndian.Uint64(data[40:48])     // Get global Counters (BytesRcvd)
+	d.Metadata.Counts.BytesSent = binary.BigEndian.Uint64(data[48:56])     // Get global Counters (BytesSent)
+	d.Metadata.Counts.PacketsRcvd = binary.BigEndian.Uint64(data[56:64])   // Get global Counters (PacketsRcvd)
+	d.Metadata.Counts.PacketsSent = binary.BigEndian.Uint64(data[64:72])   // Get global Counters (PacketsSent)
 	pos := 72
 
 	// Get block information
@@ -298,7 +298,7 @@ func (d *GPDir) Unmarshal(r ReadWriteSeekCloser) error {
 	for i := 0; i < nBlocks; i++ {
 		d.BlockTraffic[i].NumV4Entries = uint64(binary.BigEndian.Uint32(data[pos : pos+4]))
 		d.BlockTraffic[i].NumV6Entries = uint64(binary.BigEndian.Uint32(data[pos+4 : pos+8]))
-		d.BlockTraffic[i].NumDrops = int(binary.BigEndian.Uint32(data[pos+8 : pos+12]))
+		d.BlockTraffic[i].NumDrops = uint64(binary.BigEndian.Uint32(data[pos+8 : pos+12]))
 		thisTimestamp := lastTimestamp + int64(binary.BigEndian.Uint32(data[pos+12:pos+16]))
 		for j := 0; j < int(types.ColIdxCount); j++ {
 			d.BlockMetadata[j].BlockList[i].Timestamp = thisTimestamp

--- a/pkg/goDB/storage/gpfile/gpfile_test.go
+++ b/pkg/goDB/storage/gpfile/gpfile_test.go
@@ -410,7 +410,7 @@ func writeDummyBlock(timestamp int64, dir *GPDir, dummyByte byte) error {
 	return dir.WriteBlocks(timestamp, TrafficMetadata{
 		NumV4Entries: uint64(dummyByte),
 		NumV6Entries: uint64(dummyByte),
-		NumDrops:     int(dummyByte),
+		NumDrops:     uint64(dummyByte),
 	}, types.Counters{
 		BytesRcvd:   uint64(dummyByte),
 		BytesSent:   uint64(dummyByte),


### PR DESCRIPTION
This should remove any issues regarding drop counter display on the `list` target, but also be seen as a cleanup. I don't really know why any of these counters should be signed integers, not only because of the inherent dangers of casting issues, but also because we'd be wasting half of the available range for all of them by using signed counters _and_ need more explicit casts in the code.

@els0r Maybe have a shot at converting the DB in question with this code, it should work fine now.