### PR TITLE
[feature] Add command line option to enable goQuery profiling

### DIFF
--- a/cmd/goQuery/cmd/profiling.go
+++ b/cmd/goQuery/cmd/profiling.go
@@ -5,10 +5,36 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/pprof"
+
+	"github.com/els0r/goProbe/cmd/goQuery/pkg/conf"
+	"github.com/els0r/goProbe/pkg/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-func startProfiling(dirPath string) error {
+func initProfiling(_ *cobra.Command, args []string) error {
+	// Setup profiling (if enabled)
+	profilingOutputDir := viper.GetString(conf.ProfilingOutputDir)
+	if profilingOutputDir != "" {
+		logging.Logger().With(conf.ProfilingOutputDir, profilingOutputDir).Debug("setting up profiling")
+		if err := startProfiling(profilingOutputDir); err != nil {
+			return fmt.Errorf("failed to initialize profiling: %w", err)
+		}
+	}
+	return nil
+}
 
+func finishProfiling(_ *cobra.Command, _ []string) error {
+	profilingOutputDir := viper.GetString(conf.ProfilingOutputDir)
+	if profilingOutputDir != "" {
+		if err := stopProfiling(profilingOutputDir); err != nil {
+			return fmt.Errorf("failed to finalize profiling: %w", err)
+		}
+	}
+	return nil
+}
+
+func startProfiling(dirPath string) error {
 	err := os.MkdirAll(dirPath, 0750)
 	if err != nil {
 		return fmt.Errorf("failed to create pprof directory: %w", err)

--- a/cmd/goQuery/cmd/profiling.go
+++ b/cmd/goQuery/cmd/profiling.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+)
+
+func startProfiling(dirPath string) error {
+
+	err := os.MkdirAll(dirPath, 0750)
+	if err != nil {
+		return fmt.Errorf("failed to create pprof directory: %w", err)
+	}
+
+	f, err := os.Create(filepath.Join(filepath.Clean(dirPath), "goquery_cpu_profile.pprof"))
+	if err != nil {
+		return fmt.Errorf("failed to create CPU profile file: %w", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		return fmt.Errorf("failed to start CPU profiling: %w", err)
+	}
+
+	return nil
+}
+
+func stopProfiling(dirPath string) error {
+
+	pprof.StopCPUProfile()
+
+	f, err := os.Create(filepath.Join(filepath.Clean(dirPath), "goquery_mem_profile.pprof"))
+	if err != nil {
+		return fmt.Errorf("failed to create memory profile file: %w", err)
+	}
+	if err := pprof.Lookup("allocs").WriteTo(f, 0); err != nil {
+		return fmt.Errorf("failed to start memory profiling: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/goQuery/cmd/root.go
+++ b/cmd/goQuery/cmd/root.go
@@ -90,7 +90,7 @@ func init() {
 	flags.BoolVarP(&cmdLineParams.Sum, "sum", "", false, helpMap["Sum"])
 	flags.BoolVarP(&cmdLineParams.Version, "version", "v", false, "Print version information and exit\n")
 
-	flags.StringVar(&cmdLineParams.ProfilingOutputDir, "profiling-output-dir", "", "Enable and set directory to store CPU and memory profiles")
+	flags.StringVar(&cmdLineParams.ProfilingOutputDir, conf.ProfilingOutputDir, "", "Enable and set directory to store CPU and memory profiles")
 
 	flags.StringVarP(&cmdLineParams.Ifaces, "ifaces", "i", "", helpMap["Ifaces"])
 	flags.StringVarP(&cmdLineParams.Condition, "condition", "c", "", helpMap["Condition"])

--- a/cmd/goQuery/pkg/conf/conf.go
+++ b/cmd/goQuery/pkg/conf/conf.go
@@ -42,4 +42,8 @@ const (
 	// Time
 	First = "first"
 	Last  = "last"
+
+	// Profiling
+	profilingKey       = "profiling"
+	ProfilingOutputDir = profilingKey + ".output-dir"
 )

--- a/pkg/query/args.go
+++ b/pkg/query/args.go
@@ -88,6 +88,9 @@ type Args struct {
 	// stores who produced these args (caller)
 	Caller string `json:"caller,omitempty" yaml:"caller,omitempty"`
 
+	// enables / sets output for CPU & memory profiling
+	ProfilingOutputDir string `json:"profiling_output_dir,omitempty" yaml:"profiling_output_dir,omitempty"`
+
 	// outputs is unexported
 	outputs []io.Writer
 }

--- a/pkg/query/args.go
+++ b/pkg/query/args.go
@@ -88,9 +88,6 @@ type Args struct {
 	// stores who produced these args (caller)
 	Caller string `json:"caller,omitempty" yaml:"caller,omitempty"`
 
-	// enables / sets output for CPU & memory profiling
-	ProfilingOutputDir string `json:"profiling_output_dir,omitempty" yaml:"profiling_output_dir,omitempty"`
-
 	// outputs is unexported
 	outputs []io.Writer
 }


### PR DESCRIPTION
Simple enough, basically re-uses proven code recently removed from goProbe after moving to API based profiling.

Closes #168 