### PR TITLE
[bugfix] Add timeout parameter and improve error output for gpctl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.deb
 *.test
 absolute
+cmd/gpctl/gpctl
 cmd/goProbe/goProbe
 cmd/goQuery/goQuery
 cmd/goConvert/goConvert

--- a/cmd/gpctl/cmd/config.go
+++ b/cmd/gpctl/cmd/config.go
@@ -21,6 +21,8 @@ import (
 const (
 	flagFile   = "file"
 	flagSilent = "silent"
+
+	defaultQueryDeadline = 3 * time.Second
 )
 
 var (
@@ -40,7 +42,7 @@ show the configuration for them. Otherwise, all configurations are printed
 The list of interfaces is ignored if --file is provided to reload
 goprobe's runtime configuration
 `,
-	RunE:          wrapCancellationContext(time.Second, configEntrypoint),
+	RunE:          wrapCancellationContext(configEntrypoint),
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }

--- a/cmd/gpctl/cmd/config.go
+++ b/cmd/gpctl/cmd/config.go
@@ -22,7 +22,7 @@ const (
 	flagFile   = "file"
 	flagSilent = "silent"
 
-	defaultQueryDeadline = 3 * time.Second
+	defaultRequestTimeout = 3 * time.Second
 )
 
 var (

--- a/cmd/gpctl/cmd/root.go
+++ b/cmd/gpctl/cmd/root.go
@@ -50,7 +50,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.gpctl.yaml)")
 
 	rootCmd.PersistentFlags().StringP(conf.GoProbeServerAddr, "s", "", "server address of goProbe API")
-	rootCmd.PersistentFlags().DurationP(conf.QueryTimeout, "t", defaultQueryDeadline, "timeout / deadline for goProbe API query")
+	rootCmd.PersistentFlags().DurationP(conf.RequestTimeout, "t", defaultRequestTimeout, "request timeout / deadline for goProbe API")
 
 	_ = viper.BindPFlags(rootCmd.PersistentFlags())
 }
@@ -124,7 +124,7 @@ func wrapCancellationContext(f entrypointE) runE {
 		defer stop()
 
 		// calls to the api shouldn't take longer than one second
-		ctx, cancel := context.WithTimeout(sdCtx, viper.GetDuration(conf.QueryTimeout))
+		ctx, cancel := context.WithTimeout(sdCtx, viper.GetDuration(conf.RequestTimeout))
 		defer cancel()
 
 		return f(ctx, cmd, args)

--- a/cmd/gpctl/cmd/root.go
+++ b/cmd/gpctl/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/els0r/goProbe/cmd/gpctl/pkg/conf"
 	"github.com/els0r/goProbe/pkg/api"
@@ -37,7 +36,6 @@ func Execute() {
 		)
 		if logErr != nil {
 			fmt.Fprintf(os.Stderr, "Failed to instantiate CLI logger: %v\n", logErr)
-
 			fmt.Fprintf(os.Stderr, "Error running command: %s\n", err)
 			os.Exit(1)
 		}
@@ -52,6 +50,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.gpctl.yaml)")
 
 	rootCmd.PersistentFlags().StringP(conf.GoProbeServerAddr, "s", "", "server address of goProbe API")
+	rootCmd.PersistentFlags().DurationP(conf.QueryTimeout, "t", defaultQueryDeadline, "timeout / deadline for goProbe API query")
 
 	_ = viper.BindPFlags(rootCmd.PersistentFlags())
 }
@@ -118,13 +117,14 @@ func rootEntrypoint(cmd *cobra.Command, args []string) error {
 type entrypointE func(ctx context.Context, cmd *cobra.Command, args []string) error
 type runE func(cmd *cobra.Command, args []string) error
 
-func wrapCancellationContext(timeout time.Duration, f entrypointE) runE {
+func wrapCancellationContext(f entrypointE) runE {
+
 	return func(cmd *cobra.Command, args []string) error {
 		sdCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 		defer stop()
 
 		// calls to the api shouldn't take longer than one second
-		ctx, cancel := context.WithTimeout(sdCtx, timeout)
+		ctx, cancel := context.WithTimeout(sdCtx, viper.GetDuration(conf.QueryTimeout))
 		defer cancel()
 
 		return f(ctx, cmd, args)

--- a/cmd/gpctl/pkg/conf/conf.go
+++ b/cmd/gpctl/pkg/conf/conf.go
@@ -3,5 +3,5 @@ package conf
 const (
 	serverKey         = "server"
 	GoProbeServerAddr = serverKey + ".addr"
-	QueryTimeout      = "timeout"
+	RequestTimeout    = "timeout"
 )

--- a/cmd/gpctl/pkg/conf/conf.go
+++ b/cmd/gpctl/pkg/conf/conf.go
@@ -3,4 +3,5 @@ package conf
 const (
 	serverKey         = "server"
 	GoProbeServerAddr = serverKey + ".addr"
+	QueryTimeout      = "timeout"
 )


### PR DESCRIPTION
Tasks done:

- New `-t|--timeout` duration command line parameter (new default: `3s`)
- Disables duplicate error output in `status` call
- Disables the emission of usage info if the error is context related (timeout / cancellation)

Closes #177 