### PR TITLE
[bugfix] Add API recursion detection using a runtime ID

### DIFF
--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -1,8 +1,9 @@
 package api
 
 import (
-	"net/http"
+	"errors"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/els0r/goProbe/pkg/logging"
@@ -77,6 +78,19 @@ func RateLimitMiddleware(limiter *rate.Limiter) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if !limiter.Allow() {
 			c.AbortWithStatus(http.StatusTooManyRequests)
+			return
+		}
+		c.Next()
+	}
+}
+
+// RecursionDetectorMiddleware provides a means to avoid having a distributed querier query itself
+// into oblivion
+func RecursionDetectorMiddleware(headerKey, match string) gin.HandlerFunc {
+	ErrRecursionDetected := errors.New("API query recursion detected, cross-check host configuration")
+	return func(c *gin.Context) {
+		if c.Request.Header.Get(headerKey) == match {
+			logging.FromContext(c.Request.Context()).Error(c.AbortWithError(http.StatusBadRequest, ErrRecursionDetected))
 			return
 		}
 		c.Next()

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/els0r/goProbe/pkg/api"
+	"github.com/els0r/goProbe/pkg/goDB/info"
 	"github.com/els0r/goProbe/pkg/telemetry/metrics"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,9 +16,14 @@ import (
 )
 
 const (
+
+	// RuntimeIDHeaderKey denotes the header name / key that identifies the server runtime ID
+	RuntimeIDHeaderKey = "X-GOPROBE-RUNTIME-ID"
+
 	maxMultipartMemory = 32 << 20 // 32 MiB
 )
 
+// Option denotes a functional option for the DefaultServer
 type Option func(*DefaultServer)
 
 // DefaultServer is the default API server, allowing middlewares and settings to be
@@ -123,6 +129,7 @@ func (server *DefaultServer) registerMiddlewares() {
 	server.router.Use(
 		api.TraceIDMiddleware(),
 		api.RequestLoggingMiddleware(),
+		api.RecursionDetectorMiddleware(RuntimeIDHeaderKey, info.RuntimeID()),
 	)
 
 	if server.metrics {

--- a/pkg/goDB/info/hostid.go
+++ b/pkg/goDB/info/hostid.go
@@ -2,12 +2,14 @@ package info
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -16,6 +18,12 @@ const (
 	fallbackIDFileName = "host.id"
 	hostIDLen          = 16 // 128 bit in line with defaults of /etc/machine-id
 )
+
+var runtimeID string
+
+func init() {
+	runtimeID = generateRuntimeID()
+}
 
 // GetHostID is a method that returns a system's unique identifier
 func GetHostID(fallbackPath string) string {
@@ -30,6 +38,11 @@ func GetHostID(fallbackPath string) string {
 	}
 
 	return id
+}
+
+// RuntimeID returns the unique runtime ID of this binary
+func RuntimeID() string {
+	return runtimeID
 }
 
 func fallbackHostID(basePath string) (string, error) {
@@ -78,4 +91,9 @@ func generateHostID() (string, error) {
 
 func sanitizeHostID(idData []byte) string {
 	return strings.TrimRight(string(idData), "\n")
+}
+
+func generateRuntimeID() string {
+	hash := sha256.Sum256([]byte(time.Now().UTC().String()))
+	return fmt.Sprintf("%s_%x", GetHostID(""), hash)
 }


### PR DESCRIPTION
@els0r Fairly simple, provides a runtime ID (generated from the nanosecond timestamp + hostID (if available), which should provide enough entropy) which is setup per-binary and then cross-checked via the request headers. If a client queries itself the runtime ID will be identical (because it's the same binary) and hence be rejected (I opted for throwing an error to avoid confusion on the user side - after all it's a configuration error which should be fixed. Since the distributed querier will receive a HTTP 400 it will not retry _and_ simply handle all other requests gracefully while still showing the error and hence prompting the caller to fix the issue).
Using a runtime random ID (instead of using the user-agent and / or the hostID only) this allows us to e.g. still run multiple global query instances on the same host and also support chained queries via multiple global queries in the future.

Closes #159 