### PR TITLE
[feature] Perform packet parsing in buffer mode to speed up draining

### DIFF
--- a/pkg/capture/buffer.go
+++ b/pkg/capture/buffer.go
@@ -4,16 +4,16 @@ import (
 	"unsafe"
 
 	"github.com/els0r/goProbe/cmd/goProbe/config"
+	"github.com/els0r/goProbe/pkg/capture/capturetypes"
 	"github.com/fako1024/gotools/concurrency"
-	"github.com/fako1024/slimcap/capture"
 	"golang.org/x/sys/unix"
 )
 
 const (
 
-	// bufElementAddSize denotes the required fixed size component for the pktType and pktSize
-	// values per element: 1 (pktType) + 4 (uint32)
-	bufElementAddSize = 5
+	// bufElementAddSize denotes the required size for a buffer element
+	// (size of EPHash + 4 bytes for pktSize + 1 byte for pktType, isIPv4, auxInfo, errno, respectively)
+	bufElementSize = capturetypes.EPHashSize + 8
 )
 
 var (
@@ -29,21 +29,8 @@ var (
 // LocalBuffer denotes a local packet buffer used to temporarily capture packets
 // from the source (e.g. during rotation) to avoid a ring / kernel buffer overflow
 type LocalBuffer struct {
-	data []byte // continuous buffer slice
-
-	snapLen     int // capture length / snaplen for the underlying packet source
-	elementSize int // size of an individual element stored in the buffer
-
-	bufPos int // current position in continuous buffer slice
-}
-
-// NewLocalBuffer instantiates a new buffer
-func NewLocalBuffer(captureHandle capture.SourceZeroCopy) *LocalBuffer {
-	p := captureHandle.NewPacket()
-	return &LocalBuffer{
-		snapLen:     len(p.IPLayer()),
-		elementSize: len(p.IPLayer()) + bufElementAddSize, // snaplen + sizes for pktType and pktSize
-	}
+	data   []byte // continuous buffer slice
+	bufPos int    // current position in buffer slice
 }
 
 // Assign sets the actual underlying data slice (obtained from a memory pool) of this buffer
@@ -60,7 +47,7 @@ func (l *LocalBuffer) Release() {
 
 // Add adds an element to the buffer, returning ok = true if successful
 // If the buffer is full / may not grow any further, ok is false
-func (l *LocalBuffer) Add(ipLayer capture.IPLayer, pktType byte, pktSize uint32) (ok bool) {
+func (l *LocalBuffer) Add(epHash capturetypes.EPHash, pktType byte, pktSize uint32, isIPv4 bool, auxInfo byte, errno capturetypes.ParsingErrno) (ok bool) {
 
 	// Ascertain the current size of the underlying data slice (from the memory pool)
 	// and grow if required
@@ -68,8 +55,8 @@ func (l *LocalBuffer) Add(ipLayer capture.IPLayer, pktType byte, pktSize uint32)
 		l.data = make([]byte, initialBufferSize)
 	}
 
-	// If required, grow the buffer
-	if l.bufPos+l.elementSize >= len(l.data) {
+	// If required, attempt to grow the buffer
+	if l.bufPos+bufElementSize >= len(l.data) {
 
 		// If the buffer size is already at its limit, reject the new element
 		if len(l.data) >= maxBufferSize {
@@ -80,24 +67,36 @@ func (l *LocalBuffer) Add(ipLayer capture.IPLayer, pktType byte, pktSize uint32)
 	}
 
 	// Transfer data to the buffer
-	copy(l.data[l.bufPos:], ipLayer)
-	l.data[l.bufPos+l.snapLen] = pktType
-	*(*uint32)(unsafe.Pointer(&l.data[l.bufPos+l.snapLen+1])) = pktSize // #nosec G103
+	copy(l.data[l.bufPos:], epHash[:])
+	l.data[l.bufPos+capturetypes.EPHashSize] = pktType
+	if isIPv4 {
+		l.data[l.bufPos+capturetypes.EPHashSize+1] = 0
+	} else {
+		l.data[l.bufPos+capturetypes.EPHashSize+1] = 1
+	}
+	l.data[l.bufPos+capturetypes.EPHashSize+2] = auxInfo
+	*(*int8)(unsafe.Pointer(&l.data[l.bufPos+capturetypes.EPHashSize+3])) = int8(errno) // #nosec G103
+	*(*uint32)(unsafe.Pointer(&l.data[l.bufPos+capturetypes.EPHashSize+4])) = pktSize   // #nosec G103
 
 	// Increment buffer position
-	l.bufPos += l.elementSize
+	l.bufPos += bufElementSize
 
 	return true
 }
 
-// Get fetches the i-th element from the buffer (zero-copy)
-func (l *LocalBuffer) Get(i int) (capture.IPLayer, byte, uint32) {
-	return l.data[i*l.elementSize : i*l.elementSize+l.snapLen], l.data[i*l.elementSize+l.snapLen], *(*uint32)(unsafe.Pointer(&l.data[i*l.elementSize+l.snapLen+1])) // #nosec G103
+// Get fetches the i-th element from the buffer
+func (l *LocalBuffer) Get(i int) (epHash capturetypes.EPHash, pktType byte, pktSize uint32, isIPv4 bool, auxInfo byte, errno capturetypes.ParsingErrno) {
+	return capturetypes.EPHash(l.data[i*bufElementSize : i*bufElementSize+capturetypes.EPHashSize]),
+		l.data[i*bufElementSize+capturetypes.EPHashSize],
+		*(*uint32)(unsafe.Pointer(&l.data[i*bufElementSize+capturetypes.EPHashSize+4])),
+		l.data[i*bufElementSize+capturetypes.EPHashSize+1] > 0,
+		l.data[i*bufElementSize+capturetypes.EPHashSize+2],
+		capturetypes.ParsingErrno(*(*int8)(unsafe.Pointer(&l.data[i*bufElementSize+capturetypes.EPHashSize+3]))) // #nosec G103
 }
 
 // N returns the number of elements in the buffer
 func (l *LocalBuffer) N() int {
-	return l.bufPos / l.elementSize
+	return l.bufPos / bufElementSize
 }
 
 ///////////////////////////////////////////////////////////////////////////////////

--- a/pkg/capture/capture_test.go
+++ b/pkg/capture/capture_test.go
@@ -226,7 +226,8 @@ func BenchmarkRotation(b *testing.B) {
 	flowLog := NewFlowLog()
 	for i := uint64(0); i < nFlows; i++ {
 		*(*uint64)(unsafe.Pointer(&ipLayer[16])) = i // #nosec G103
-		require.Equal(b, capturetypes.ErrnoOK, flowLog.Add(ipLayer, capture.PacketOutgoing, 128))
+		epHash, isIPv4, auxInfo, errno := ParsePacket(ipLayer)
+		require.Equal(b, capturetypes.ErrnoOK, flowLog.Add(epHash, capture.PacketOutgoing, 128, isIPv4, auxInfo, errno))
 	}
 	for _, flow := range flowLog.flowMap {
 		flow.directionConfidenceHigh = true
@@ -264,7 +265,8 @@ func BenchmarkRotation(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			require.Nil(b, testLog.Add(pkt.IPLayer(), capture.PacketOutgoing, 128))
+			epHash, isIPv4, auxInfo, errno := ParsePacket(pkt.IPLayer())
+			require.Equal(b, capturetypes.ErrnoOK, testLog.Add(epHash, capture.PacketOutgoing, 128, isIPv4, auxInfo, errno))
 		}
 	})
 

--- a/pkg/capture/capturetypes/packet.go
+++ b/pkg/capture/capturetypes/packet.go
@@ -40,10 +40,12 @@ const (
 	UDP    = 0x11 // UDP : 17
 	ESP    = 0x32 // ESP : 50
 	ICMPv6 = 0x3A // ICMPv6 : 58
+
+	EPHashSize = 37 // EPHashSize : The (static) length of an EPHash
 )
 
 // EPHash is a typedef that allows us to replace the type of hash
-type EPHash [37]byte
+type EPHash [EPHashSize]byte
 
 // Reverse calculates the reverse of an EPHash (i.e. source / destination switched)
 func (h EPHash) Reverse() (rev EPHash) {

--- a/pkg/capture/capturetypes/parsing_error.go
+++ b/pkg/capture/capturetypes/parsing_error.go
@@ -1,7 +1,7 @@
 package capturetypes
 
 // ParsingErrno denotes a non-critical packet parsing error / failure
-type ParsingErrno int
+type ParsingErrno int8
 
 const (
 

--- a/pkg/capture/flow.go
+++ b/pkg/capture/flow.go
@@ -174,9 +174,8 @@ func ParsePacket(ipLayer capture.IPLayer) (epHash capturetypes.EPHash, isIPv4 bo
 // Add a packet to the flow log. If the packet belongs to a flow
 // already present in the log, the flow will be updated. Otherwise,
 // a new flow will be created.
-func (f *FlowLog) Add(ipLayer capture.IPLayer, pktType capture.PacketType, pktTotalLen uint32) capturetypes.ParsingErrno {
+func (f *FlowLog) Add(epHash capturetypes.EPHash, pktType byte, pktSize uint32, isIPv4 bool, auxInfo byte, errno capturetypes.ParsingErrno) capturetypes.ParsingErrno {
 
-	epHash, isIPv4, auxInfo, errno := ParsePacket(ipLayer)
 	if errno > capturetypes.ErrnoOK {
 		if errno.ParsingFailed() {
 			return errno
@@ -186,13 +185,13 @@ func (f *FlowLog) Add(ipLayer capture.IPLayer, pktType capture.PacketType, pktTo
 
 	// update or assign the flow
 	if flowToUpdate, existsHash := f.flowMap[string(epHash[:])]; existsHash {
-		flowToUpdate.UpdateFlow(epHash, auxInfo, pktType, pktTotalLen)
+		flowToUpdate.UpdateFlow(epHash, auxInfo, pktType, pktSize)
 	} else {
 		epHashReverse := epHash.Reverse()
 		if flowToUpdate, existsReverseHash := f.flowMap[string(epHashReverse[:])]; existsReverseHash {
-			flowToUpdate.UpdateFlow(epHashReverse, auxInfo, pktType, pktTotalLen)
+			flowToUpdate.UpdateFlow(epHashReverse, auxInfo, pktType, pktSize)
 		} else {
-			f.flowMap[string(epHash[:])] = NewFlow(epHash, isIPv4, auxInfo, pktType, pktTotalLen)
+			f.flowMap[string(epHash[:])] = NewFlow(epHash, isIPv4, auxInfo, pktType, pktSize)
 		}
 	}
 

--- a/pkg/e2etest/types.go
+++ b/pkg/e2etest/types.go
@@ -166,8 +166,9 @@ func (m mockIfaces) BuildResults(t *testing.T, testDir string, resGoQuery *resul
 	res.Query.Attributes = []string{types.SIPName, types.DIPName, types.DportName, types.ProtoName}
 	hostname, err := os.Hostname()
 	require.Nil(t, err)
+	hostID := info.GetHostID(testDir)
 	for i := 0; i < len(res.Rows); i++ {
-		res.Rows[i].Labels.HostID = info.GetHostID(testDir)
+		res.Rows[i].Labels.HostID = hostID
 		res.Rows[i].Labels.Hostname = hostname
 	}
 


### PR DESCRIPTION
@els0r This was easier than anticipated and should provide additional time and space savings during rotations. IMHO it should be fine to reduce whatever overall rotation buffer you've defined by 50% (will still allow more elements in the buffer per rotation). For additional info / benefits, check out the summary in #193 .

Note that this PR is filed against the #171 branch in order to avoid merge conflicts against all the code refactoring. Should be merged only _after_ the referenced PR is merged.

Closes #193 