### PR TITLE
[feature] Provide QuerierAnyable interface extension to allow querying all available hosts

### DIFF
--- a/cmd/global-query/pkg/distributed/querier.go
+++ b/cmd/global-query/pkg/distributed/querier.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/els0r/goProbe/cmd/global-query/pkg/hosts"
 	"github.com/els0r/goProbe/pkg/api/goprobe/client"
 	"github.com/els0r/goProbe/pkg/query"
 	"github.com/els0r/goProbe/pkg/results"
@@ -26,6 +27,14 @@ type Querier interface {
 
 	// CreateQueryWorkload prepares and executes the workload required to perform the query
 	CreateQueryWorkload(ctx context.Context, host string, args *query.Args) (*QueryWorkload, error)
+}
+
+// QuerierAnyable extends a "common" Querier with the support to retrieve a list of all hosts / targets
+// available to the Querier
+type QuerierAnyable interface {
+
+	// AllHosts returns a list of all hosts / targets available to the Querier
+	AllHosts() (hosts.Hosts, error)
 }
 
 // APIClientQuerier implements an API-based querier, fulfilling the Querier interface
@@ -76,6 +85,16 @@ func (a *APIClientQuerier) CreateQueryWorkload(_ context.Context, host string, a
 	}
 
 	return qw, nil
+}
+
+// AllHosts returns a list of all hosts / targets available to the querier
+func (a *APIClientQuerier) AllHosts() (hostList hosts.Hosts, err error) {
+	hostList = make([]string, 0, len(a.apiEndpoints))
+	for host := range a.apiEndpoints {
+		hostList = append(hostList, host)
+	}
+
+	return
 }
 
 // errorRunner is used to propagate an error all the way to the aggregation routine

--- a/cmd/global-query/pkg/distributed/query.go
+++ b/cmd/global-query/pkg/distributed/query.go
@@ -72,7 +72,7 @@ func (q *QueryRunner) Run(ctx context.Context, args *query.Args) (*results.Resul
 	// query pipeline setup
 	// sets up a fan-out, fan-in query processing pipeline
 	numRunners := len(hostList)
-	if q.maxConcurrent > 0 {
+	if q.maxConcurrent > 0 && q.maxConcurrent < numRunners {
 		numRunners = q.maxConcurrent
 	}
 

--- a/cmd/global-query/pkg/distributed/query.go
+++ b/cmd/global-query/pkg/distributed/query.go
@@ -61,9 +61,9 @@ func (q *QueryRunner) Run(ctx context.Context, args *query.Args) (*results.Resul
 		return nil, fmt.Errorf("failed to prepare query statement: %w", err)
 	}
 
-	hostList, err := q.resolver.Resolve(ctx, queryArgs.QueryHosts)
+	hostList, err := q.prepareHostList(ctx, args.QueryHosts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve host list: %w", err)
+		return nil, err // prepareHostList() returns formatted error
 	}
 
 	// log the query
@@ -93,6 +93,29 @@ func (q *QueryRunner) Run(ctx context.Context, args *query.Args) (*results.Resul
 	finalResult.Summary.Hits.Displayed = len(finalResult.Rows)
 
 	return finalResult, nil
+}
+
+func (q *QueryRunner) prepareHostList(ctx context.Context, queryHosts string) (hostList hosts.Hosts, err error) {
+
+	// Handle ANY (all hosts) case
+	if types.IsAnySelector(queryHosts) {
+		if querierAnyable, ok := q.querier.(QuerierAnyable); ok {
+			if hostList, err = querierAnyable.AllHosts(); err != nil {
+				err = fmt.Errorf("failed to extract list of all hosts: %w", err)
+			}
+		} else {
+			err = errors.New("querier type does not support querying all hosts")
+		}
+
+		return
+	}
+
+	// Default handling via resolver
+	if hostList, err = q.resolver.Resolve(ctx, queryHosts); err != nil {
+		err = fmt.Errorf("failed to resolve host list: %w", err)
+	}
+
+	return
 }
 
 // prepareQueries creates query workloads for all hosts in the host list and returns the channel it sends the

--- a/cmd/goquery_completion/ifaces.go
+++ b/cmd/goquery_completion/ifaces.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/els0r/goProbe/pkg/goDB/info"
+	"github.com/els0r/goProbe/pkg/types"
 	"github.com/els0r/goProbe/pkg/util"
 )
 
@@ -61,11 +62,11 @@ func ifaces(args []string) []string {
 
 		var suggs []suggestion
 
-		if len(ifaces) == 1 && strings.HasPrefix("any", strings.ToLower(last(ifaces))) {
+		if len(ifaces) == 1 && strings.HasPrefix(types.AnySelector, strings.ToLower(last(ifaces))) {
 			suggs = append(suggs, suggestion{"ANY", "ANY (query all interfaces)", true})
 		} else {
 			for _, iface := range ifaces {
-				if strings.ToLower(iface) == "any" {
+				if types.IsAnySelector(iface) {
 					return knownSuggestions{[]suggestion{}}
 				}
 			}

--- a/pkg/api/goprobe/client/query.go
+++ b/pkg/api/goprobe/client/query.go
@@ -26,8 +26,8 @@ func (c *Client) Query(ctx context.Context, args *query.Args) (*results.Result, 
 	}
 
 	// we need more results before truncating
-	if args.NumResults < query.DefaultNumResults {
-		args.NumResults = query.DefaultNumResults
+	if queryArgs.NumResults < query.DefaultNumResults {
+		queryArgs.NumResults = query.DefaultNumResults
 	}
 
 	var res = new(results.Result)

--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -323,12 +323,12 @@ func createWorkManager(dbPath string, iface string, tfirst, tlast int64, query *
 	return
 }
 
-func parseIfaceList(dbPath string, ifacelist string) ([]string, error) {
-	if ifacelist == "" {
+func parseIfaceList(dbPath string, ifaceList string) ([]string, error) {
+	if ifaceList == "" {
 		return nil, errors.New("no interface(s) specified")
 	}
 
-	if strings.ToLower(ifacelist) == "any" {
+	if types.IsAnySelector(ifaceList) {
 		ifaces, err := info.GetInterfaces(dbPath)
 		if err != nil {
 			return nil, err
@@ -336,7 +336,7 @@ func parseIfaceList(dbPath string, ifacelist string) ([]string, error) {
 		return ifaces, nil
 	}
 
-	ifaces, err := validateIfaceNames(ifacelist)
+	ifaces, err := validateIfaceNames(ifaceList)
 	if err != nil {
 		return nil, err
 	}
@@ -358,8 +358,8 @@ func validateIfaceName(iface string) error {
 	return nil
 }
 
-func validateIfaceNames(ifacelist string) ([]string, error) {
-	ifaces := strings.Split(ifacelist, ",")
+func validateIfaceNames(ifaceList string) ([]string, error) {
+	ifaces := strings.Split(ifaceList, ",")
 	for _, iface := range ifaces {
 		if err := validateIfaceName(iface); err != nil {
 			return nil, err

--- a/pkg/query/args.go
+++ b/pkg/query/args.go
@@ -194,7 +194,7 @@ func (a *Args) Prepare(writers ...io.Writer) (*Statement, error) {
 
 	// insert iface attribute here in case multiple interfaces where specified and the
 	// interface column was not added as an attribute
-	if (len(s.Ifaces) > 1 || strings.Contains(a.Ifaces, "any")) &&
+	if (len(s.Ifaces) > 1 || strings.Contains(a.Ifaces, types.AnySelector)) &&
 		!strings.Contains(a.Query, "iface") {
 		selector.Iface = true
 	}

--- a/pkg/query/args.go
+++ b/pkg/query/args.go
@@ -252,7 +252,7 @@ func (a *Args) Prepare(writers ...io.Writer) (*Statement, error) {
 	s.MaxMemPct = a.MaxMemPct
 
 	// check limits flag
-	if !(0 < a.NumResults) {
+	if a.NumResults <= 0 {
 		return s, errors.New("the printed row limit must be greater than 0")
 	}
 	s.NumResults = a.NumResults

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -99,6 +99,14 @@ const (
 	KeyWidthIPv6 = sipDipIPv6Width + nonIPKeysWidth
 )
 
+// AnySelector denotes any / all (interfaces, hosts, ...)
+const AnySelector = "any"
+
+// IsAnySelector returns if the provided selector is "ANY" (case insensitive)
+func IsAnySelector(input string) bool {
+	return strings.EqualFold(input, AnySelector)
+}
+
 // RawIPToAddr converts an ip byte slice to an actual netip.Addr
 func RawIPToAddr(ip []byte) netip.Addr {
 	zeros := numZeros(ip)


### PR DESCRIPTION
@els0r This is a simple non-breaking extension of the existing `Querier` interface that allows any Querier implementation to optionally support an "any" query (as I've implemented for the current distributed one so that one can select "any" for the `QueryHosts` argument, triggering a query to all configured hosts). It is my understanding that for OSAG you're going to provide custom logic anyway so I assume this doesn't limit you in any way. If I'm wrong please let me know...

Closes #217 