### PR TITLE
[feature] Implement functional filter capabilities for aggregate hashmaps

### DIFF
--- a/pkg/types/hashmap/aggregate.go
+++ b/pkg/types/hashmap/aggregate.go
@@ -21,6 +21,10 @@ type KeyVal struct {
 // KeyVals denotes a list / slice of key / value pairs
 type KeyVals []KeyVal
 
+// ValFilter denotes a generic value filter (returning true if a certain filter
+// condition is met)
+type ValFilter func(Val) bool
+
 // New instantiates a new Map (a size hint can be provided)
 func New(n ...int) *Map {
 	if len(n) == 0 || n[0] == 0 {
@@ -125,11 +129,17 @@ func (a AggFlowMap) Len() int {
 }
 
 // Iter provides a map Iter to allow traversal of both underlying maps (IPv4 and IPv6)
-func (a AggFlowMap) Iter() *MetaIter {
-	return &MetaIter{
-		Iter:   a.PrimaryMap.Iter(),
-		v6Iter: a.SecondaryMap.Iter(),
+func (a AggFlowMap) Iter(opts ...MetaIterOption) *MetaIter {
+	iter := &MetaIter{
+		Iter:          a.PrimaryMap.Iter(),
+		secondaryIter: a.SecondaryMap.Iter(),
 	}
+
+	// Set functional options, if any
+	for _, opt := range opts {
+		opt(iter)
+	}
+	return iter
 }
 
 // SetOrUpdate either creates a new entry based on the provided values or

--- a/pkg/types/keyval.go
+++ b/pkg/types/keyval.go
@@ -454,3 +454,23 @@ func (c Counters) Sub(c2 Counters) Counters {
 	c.PacketsSent -= c2.PacketsSent
 	return c
 }
+
+// IsOnlyInbound returns if a set of counters represents traffic that is only inbound
+func (c Counters) IsOnlyInbound() bool {
+	return c.PacketsRcvd > 0 && c.PacketsSent == 0
+}
+
+// IsOnlyOutbound returns if a set of counters represents traffic that is only outbound
+func (c Counters) IsOnlyOutbound() bool {
+	return c.PacketsSent > 0 && c.PacketsRcvd == 0
+}
+
+// IsBidirectional returns if a set of counters represents bidrectional traffic
+func (c Counters) IsBidirectional() bool {
+	return c.PacketsRcvd > 0 && c.PacketsSent > 0
+}
+
+// IsUnidirectional returns if a set of counters represents unidirectional traffic
+func (c Counters) IsUnidirectional() bool {
+	return c.IsOnlyInbound() || c.IsOnlyOutbound()
+}


### PR DESCRIPTION
It turns out that using a functional approach was feasible after all (since after a bit of re-shuffling the code, the overhead for a default non-filter scenario is negligible, and even a filter call doesn't introduce enough overhead to significantly slow down operations on the `AggFlowMap` - after all we're operating on aggregate data already, the core hashmap or even the iterator code isn't touched).
I don't think this rather "edge"-y case and the small penalty warrants over-optimizing as long as the default case complexity is constant. If we need to squeeze out the last few percent we can do so in a future iteration.
```
                                     │    sec/op    │   sec/op     vs base               │
HashMapIterator-4                       982.8µ ± 2%   990.4µ ± 3%       ~ (p=0.436 n=10)
HashMapMetaIterator-4                   1.178m ± 3%   1.217m ± 2%  +3.34% (p=0.000 n=10)
HashMapMetaIteratorWithFilter/miss-4                  1.388m ± 2%
HashMapMetaIteratorWithFilter/hit-4                   1.559m ± 0%
```

@els0r PTAL
