### PR TITLE
[feature] Redefinition of the Querier interface

### DIFF
--- a/cmd/global-query/cmd/root.go
+++ b/cmd/global-query/cmd/root.go
@@ -126,11 +126,13 @@ func initQuerier() (distributed.Querier, error) {
 	querierType := viper.GetString(conf.QuerierType)
 	switch querierType {
 	case string(distributed.APIClientQuerierType):
-		return distributed.NewAPIClientQuerier(
+		querier, err := distributed.NewAPIClientQuerier(
 			viper.GetString(conf.QuerierConfig),
-		).SetMaxConcurrent(
-			viper.GetInt(conf.QuerierMaxConcurrent),
 		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to instantiate API client querier: %w", err)
+		}
+		return querier.SetMaxConcurrent(viper.GetInt(conf.QuerierMaxConcurrent)), nil
 	default:
 		err := fmt.Errorf("querier type %q not supported", querierType)
 		return nil, err

--- a/cmd/global-query/cmd/root.go
+++ b/cmd/global-query/cmd/root.go
@@ -126,7 +126,11 @@ func initQuerier() (distributed.Querier, error) {
 	querierType := viper.GetString(conf.QuerierType)
 	switch querierType {
 	case string(distributed.APIClientQuerierType):
-		return distributed.NewAPIClientQuerier(viper.GetString(conf.QuerierConfig))
+		return distributed.NewAPIClientQuerier(
+			viper.GetString(conf.QuerierConfig),
+		).SetMaxConcurrent(
+			viper.GetInt(conf.QuerierMaxConcurrent),
+		)
 	default:
 		err := fmt.Errorf("querier type %q not supported", querierType)
 		return nil, err

--- a/cmd/global-query/pkg/distributed/apiclient.go
+++ b/cmd/global-query/pkg/distributed/apiclient.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 
 	"log/slog"
@@ -24,9 +25,8 @@ type APIClientQuerier struct {
 	maxConcurrent int
 }
 
-const (
-	defaultMaxConcurrent = 8
-)
+// one CPU can handle more than one client call at a time
+var defaultMaxConcurrent = 2 * runtime.NumCPU()
 
 // NewAPIClientQuerier instantiates a new goProbe API-based querier. It uses the goprobe/client
 // under the hood to run queries

--- a/cmd/global-query/pkg/distributed/apiclient.go
+++ b/cmd/global-query/pkg/distributed/apiclient.go
@@ -104,7 +104,17 @@ func (a *APIClientQuerier) prepareQueries(ctx context.Context, hostList hosts.Ho
 	return workloads
 }
 
-// runQueries takes query workloads from the workloads channel, runs them, and returns a channel from which
+// AllHosts returns a list of all hosts / targets available to the querier
+func (a *APIClientQuerier) AllHosts() (hostList hosts.Hosts, err error) {
+	hostList = make([]string, 0, len(a.apiEndpoints))
+	for host := range a.apiEndpoints {
+		hostList = append(hostList, host)
+	}
+
+	return
+}
+
+// Query takes query workloads from the internal workloads channel, runs them, and returns a channel from which
 // the results can be read
 func (a *APIClientQuerier) Query(ctx context.Context, hosts hosts.Hosts, args *query.Args) <-chan *results.DistributedResult {
 	out := make(chan *results.DistributedResult, a.maxConcurrent)

--- a/cmd/global-query/pkg/distributed/apiclient.go
+++ b/cmd/global-query/pkg/distributed/apiclient.go
@@ -1,0 +1,169 @@
+package distributed
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"log/slog"
+
+	"github.com/els0r/goProbe/cmd/global-query/pkg/hosts"
+	"github.com/els0r/goProbe/pkg/api/goprobe/client"
+	"github.com/els0r/goProbe/pkg/query"
+	"github.com/els0r/goProbe/pkg/results"
+	"github.com/els0r/telemetry/logging"
+	"gopkg.in/yaml.v3"
+)
+
+// APIClientQuerier implements an API-based querier, fulfilling the Querier interface
+type APIClientQuerier struct {
+	apiEndpoints map[string]*client.Config
+
+	maxConcurrent int
+}
+
+const (
+	defaultMaxConcurrent = 8
+)
+
+// NewAPIClientQuerier instantiates a new goProbe API-based querier. It uses the goprobe/client
+// under the hood to run queries
+func NewAPIClientQuerier(cfgPath string) (*APIClientQuerier, error) {
+	a := &APIClientQuerier{
+		apiEndpoints:  make(map[string]*client.Config),
+		maxConcurrent: defaultMaxConcurrent,
+	}
+
+	// read in the endpoints config
+	f, err := os.Open(filepath.Clean(cfgPath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open config: %w", err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	err = yaml.NewDecoder(f).Decode(a.apiEndpoints)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read in config: %w", err)
+	}
+	return a, nil
+}
+
+// SetMaxConcurrent guides how many hosts are contacted to run queries concurrently. In most cases,
+// it's sufficient to set this to the amount of hosts available in configuration or the list of hosts
+// queried
+func (a *APIClientQuerier) SetMaxConcurrent(num int) *APIClientQuerier {
+	a.maxConcurrent = num
+	return a
+}
+
+// createQueryWorkload prepares and executes the workload required to perform the query
+func (a *APIClientQuerier) createQueryWorkload(_ context.Context, host string, args *query.Args) (*queryWorkload, error) {
+	qw := &queryWorkload{
+		Host: host,
+		Args: args,
+	}
+	// create the api client runner by looking up the endpoint config for the given host
+	cfg, exists := a.apiEndpoints[host]
+	if !exists {
+		err := fmt.Errorf("couldn't find endpoint configuration for host")
+
+		// inject an error runner so that the workload creation error is transported into the final
+		// result
+		qw.Runner = &errorRunner{err: err}
+	} else {
+		qw.Runner = client.NewFromConfig(cfg)
+	}
+
+	return qw, nil
+}
+
+// prepareQueries creates query workloads for all hosts in the host list and returns the channel it sends the
+// workloads on
+func (a *APIClientQuerier) prepareQueries(ctx context.Context, hostList hosts.Hosts, args *query.Args) <-chan *queryWorkload {
+	workloads := make(chan *queryWorkload)
+
+	go func(ctx context.Context) {
+		logger := logging.FromContext(ctx)
+
+		for _, host := range hostList {
+			wl, err := a.createQueryWorkload(ctx, host, args)
+			if err != nil {
+				logger.With("hostname", host).Errorf("failed to create workload: %v", err)
+			}
+			workloads <- wl
+		}
+		close(workloads)
+	}(ctx)
+
+	return workloads
+}
+
+// runQueries takes query workloads from the workloads channel, runs them, and returns a channel from which
+// the results can be read
+func (a *APIClientQuerier) Query(ctx context.Context, hosts hosts.Hosts, args *query.Args) <-chan *results.DistributedResult {
+	out := make(chan *results.DistributedResult, a.maxConcurrent)
+
+	workloads := a.prepareQueries(ctx, hosts, args)
+
+	// query pipeline setup
+	// sets up a fan-out, fan-in query processing pipeline
+	numRunners := len(hosts)
+	if 0 < a.maxConcurrent && a.maxConcurrent < numRunners {
+		numRunners = a.maxConcurrent
+	}
+
+	logger := logging.FromContext(ctx).With("runners", numRunners)
+	logger.Info("running queries")
+
+	wg := new(sync.WaitGroup)
+	wg.Add(numRunners)
+	for i := 0; i < numRunners; i++ {
+		go func(ctx context.Context) {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case wl, open := <-workloads:
+					if !open {
+						return
+					}
+
+					ctx := logging.WithFields(ctx, slog.String("host", wl.Host))
+
+					res, err := wl.Runner.Run(ctx, wl.Args)
+					if err != nil {
+						err = fmt.Errorf("failed to run query: %w", err)
+					}
+
+					qr := &results.DistributedResult{
+						Hostname: wl.Host,
+						Result:   res,
+						Error:    err,
+					}
+
+					out <- qr
+				}
+			}
+		}(ctx)
+	}
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+	return out
+}
+
+// queryWorkload denotes an individual workload to perform a query on a remote host
+type queryWorkload struct {
+	Host string
+
+	Runner query.Runner
+	Args   *query.Args
+}

--- a/cmd/global-query/pkg/distributed/querier.go
+++ b/cmd/global-query/pkg/distributed/querier.go
@@ -32,16 +32,6 @@ type QuerierAnyable interface {
 	AllHosts() (hosts.Hosts, error)
 }
 
-// AllHosts returns a list of all hosts / targets available to the querier
-func (a *APIClientQuerier) AllHosts() (hostList hosts.Hosts, err error) {
-	hostList = make([]string, 0, len(a.apiEndpoints))
-	for host := range a.apiEndpoints {
-		hostList = append(hostList, host)
-	}
-
-	return
-}
-
 // errorRunner is used to propagate an error all the way to the aggregation routine
 type errorRunner struct {
 	err error

--- a/cmd/global-query/pkg/distributed/querier.go
+++ b/cmd/global-query/pkg/distributed/querier.go
@@ -2,80 +2,27 @@ package distributed
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"path/filepath"
 
-	"github.com/els0r/goProbe/pkg/api/goprobe/client"
+	"github.com/els0r/goProbe/cmd/global-query/pkg/hosts"
 	"github.com/els0r/goProbe/pkg/query"
 	"github.com/els0r/goProbe/pkg/results"
-	"gopkg.in/yaml.v3"
 )
 
 // QuerierType denotes the type of the querier instance
 type QuerierType string
 
 const (
-
-	// APIClientQuerierType provides the name for the API-based querier
+	// APIClientQuerierType provides the name for the goProbe API-based querier
 	APIClientQuerierType QuerierType = "api"
 )
 
 // Querier provides a general interface for all query executors
 type Querier interface {
-
-	// CreateQueryWorkload prepares and executes the workload required to perform the query
-	CreateQueryWorkload(ctx context.Context, host string, args *query.Args) (*QueryWorkload, error)
-}
-
-// APIClientQuerier implements an API-based querier, fulfilling the Querier interface
-type APIClientQuerier struct {
-	apiEndpoints map[string]*client.Config
-}
-
-// NewAPIClientQuerier instantiates a new API-based querier
-func NewAPIClientQuerier(cfgPath string) (*APIClientQuerier, error) {
-	a := &APIClientQuerier{
-		apiEndpoints: make(map[string]*client.Config),
-	}
-
-	// read in the endpoints config
-	f, err := os.Open(filepath.Clean(cfgPath))
-	if err != nil {
-		return nil, fmt.Errorf("failed to open config: %w", err)
-	}
-	defer func() {
-		if cerr := f.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-
-	err = yaml.NewDecoder(f).Decode(a.apiEndpoints)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read in config: %w", err)
-	}
-	return a, nil
-}
-
-// CreateQueryWorkload prepares and executes the workload required to perform the query
-func (a *APIClientQuerier) CreateQueryWorkload(_ context.Context, host string, args *query.Args) (*QueryWorkload, error) {
-	qw := &QueryWorkload{
-		Host: host,
-		Args: args,
-	}
-	// create the api client runner by looking up the endpoint config for the given host
-	cfg, exists := a.apiEndpoints[host]
-	if !exists {
-		err := fmt.Errorf("couldn't find endpoint configuration for host")
-
-		// inject an error runner so that the workload creation error is transported into the final
-		// result
-		qw.Runner = &errorRunner{err: err}
-	} else {
-		qw.Runner = client.NewFromConfig(cfg)
-	}
-
-	return qw, nil
+	// Query runs the distributed query on the provided hosts and returns a channel from
+	// which the results can be read. It is the responsibility of the implementing type
+	// to close the channel.
+	// This may become a requirement through the interface definitions in future versions
+	Query(ctx context.Context, hosts hosts.Hosts, args *query.Args) <-chan *results.DistributedResult
 }
 
 // errorRunner is used to propagate an error all the way to the aggregation routine

--- a/cmd/global-query/pkg/distributed/querier.go
+++ b/cmd/global-query/pkg/distributed/querier.go
@@ -22,7 +22,7 @@ type Querier interface {
 	// which the results can be read. It is the responsibility of the implementing type
 	// to close the channel.
 	// This may become a requirement through the interface definitions in future versions
-	Query(ctx context.Context, hosts hosts.Hosts, args *query.Args) <-chan *results.DistributedResult
+	Query(ctx context.Context, hosts hosts.Hosts, args *query.Args) <-chan *results.Result
 }
 
 // QuerierAnyable extends a "common" Querier with the support to retrieve a list of all hosts / targets

--- a/cmd/global-query/pkg/distributed/query.go
+++ b/cmd/global-query/pkg/distributed/query.go
@@ -137,7 +137,7 @@ func aggregateResults(ctx context.Context, stmt *query.Statement, queryResults <
 
 				finalResult.HostsStatuses.SetErr(qr.Hostname, uerr)
 
-				logger.Error(qr.Err)
+				logger.Error(qr.Err())
 				continue
 			}
 

--- a/pkg/api/spec/schemas/Result.yaml
+++ b/pkg/api/spec/schemas/Result.yaml
@@ -7,6 +7,10 @@ required:
   - query
   - rows
 properties:
+  hostname:
+    type: string
+    description: Hostname of the host that was queried
+    example: hostA
   status:
     $ref: './Status.yaml'
   hosts_statuses:

--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -109,6 +109,7 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 		return nil, fmt.Errorf("failed to get system hostname: %w", err)
 	}
 	hostID := info.GetHostID(qr.dbPath)
+	result.Hostname = hostname
 
 	// assign the hostname to the list of hosts handled in this query. Here, the only one
 	defer func() {

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -19,6 +19,17 @@ var (
 	ErrorNoResults = errors.New("query returned no results")
 )
 
+// DistributedResult stores the result from a distributed query tagged with the Hostname where
+// it came from as well as a potential error encountered when _attempting_ to fetch the result
+type DistributedResult struct {
+	// Hostname from which the result originated
+	Hostname string `json:"hostname"`
+	// Result data
+	Result *Result `json:"result,omitempty"`
+	// Error encountered when fetching result
+	Error error `json:"error,omitempty"`
+}
+
 // Result bundles the data rows returned and the query meta information
 type Result struct {
 	Status        Status        `json:"status"`         // Status: the overall status of the result

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -19,25 +19,42 @@ var (
 	ErrorNoResults = errors.New("query returned no results")
 )
 
-// DistributedResult stores the result from a distributed query tagged with the Hostname where
-// it came from as well as a potential error encountered when _attempting_ to fetch the result
-type DistributedResult struct {
-	// Hostname from which the result originated
-	Hostname string `json:"hostname"`
-	// Result data
-	Result *Result `json:"result,omitempty"`
-	// Error encountered when fetching result
-	Error error `json:"error,omitempty"`
-}
-
 // Result bundles the data rows returned and the query meta information
 type Result struct {
+	Hostname string `json:"hostname,omitempty"` // Hostname: from which the result originated
+
 	Status        Status        `json:"status"`         // Status: the overall status of the result
 	HostsStatuses HostsStatuses `json:"hosts_statuses"` // HostsStatuses: the status of all hosts queried
 
 	Summary Summary `json:"summary"` // Summary: the total traffic volume and packets observed over the queried range and the interfaces that were queried
 	Query   Query   `json:"query"`   // Query: the kind of query that was run
 	Rows    Rows    `json:"rows"`    // Rows: the data rows returned
+
+	// err is the error encountered when fetching result
+	err error `json:"-"`
+}
+
+// SetErr will set the error in the status and add it to the hosts statuses
+func (hs HostsStatuses) SetErr(host string, err error) {
+	if hs == nil {
+		return
+	}
+	hs[host] = Status{
+		Code:    types.StatusError,
+		Message: err.Error(),
+	}
+}
+
+// SetErr will set the error in the result and add it to the hosts statuses
+// for the current hostname
+func (r *Result) SetErr(err error) {
+	r.err = err
+	r.HostsStatuses.SetErr(r.Hostname, err)
+}
+
+// Err returns the error in case the result carries one
+func (r *Result) Err() error {
+	return r.err
 }
 
 // Query stores the kind of query that was run
@@ -118,6 +135,7 @@ func New() *Result {
 		Status: Status{
 			Code: types.StatusOK,
 		},
+		HostsStatuses: make(HostsStatuses),
 	}
 }
 


### PR DESCRIPTION
This PR changes the structure of the `Querier` interface, making it arguably more tailored to what it's supposed to do: query hosts in the fleet and return the results for consumption.

The only requirement is that results are put on a channel, leaving choices for handling hosts concurrently up to the individual implementation.

The `APIClientQuerier` has been adjusted to set up concurrent calls to via the goProbe client internally.