### PR TITLE
[feature] Support traffic direction filters 

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ goProbe is currently set up to run on Linux based systems only (this might chang
 * Lennart Elsen
 * Fabian Kohn
 * Lorenz Breidenbach
+* Silvan Bitterli
 
 This software was initially developed at [Open Systems AG](https://www.open.ch/) in close collaboration with the [Distributed Computing Group](http://www.disco.ethz.ch/) at the [Swiss Federal Institute of Technology](https://www.ethz.ch/en.html).
 

--- a/cmd/goQuery/cmd/help.go
+++ b/cmd/goQuery/cmd/help.go
@@ -224,7 +224,7 @@ ATTRIBUTES:
       dir = {in|inbound}:         incoming but no outgoing packets
       dir = {out|outbound}:       outgoing but no incoming packets
       dir = {uni|unidirectional}: either only incoming or only outgoing packets
-      dir = {bi|bidirectional}:   both incoming and outgoing packets
+      dir = {bi|bidirectional}:   both incoming and outgoing packets (no unidir. traffic)
 
     NOTE:
       dir may only appear as (1) a top-level condition,

--- a/cmd/goQuery/cmd/help.go
+++ b/cmd/goQuery/cmd/help.go
@@ -218,13 +218,13 @@ ATTRIBUTES:
 
   Traffic Direction:
 
-    dir        Direction filter to match against aggregated results
+    direction (or dir)   Direction filter to match against aggregated results
 
     USAGE:
-      dir = in:  incoming but no outgoing packets
-      dir = out: outgoing but no incoming packets
-      dir = uni: either only incoming or only outgoing packets
-      dir = bi:  both incoming and outgoing packets
+      dir = {in|inbound}:         incoming but no outgoing packets
+      dir = {out|outbound}:       outgoing but no incoming packets
+      dir = {uni|unidirectional}: either only incoming or only outgoing packets
+      dir = {bi|bidirectional}:   both incoming and outgoing packets
 
     NOTE:
       dir may only appear as (1) a top-level condition,
@@ -233,7 +233,7 @@ ATTRIBUTES:
     EXAMPLE:
       dir = uni
       dir = in & sip = 192.168.1.34
-      dport = 22 & dir = out
+      (dport = 22 & sip = 192.168.1.34) & dir = out
 
 COMPARATIVE OPERATORS:
 

--- a/cmd/goQuery/cmd/help.go
+++ b/cmd/goQuery/cmd/help.go
@@ -216,6 +216,25 @@ ATTRIBUTES:
     EXAMPLE: "dport = 22 & proto = TCP" is equivalent to
              "port = 22 & proto = 6"
 
+  Traffic Direction:
+
+    dir        Direction filter to match against aggregated results
+
+    USAGE:
+      dir = in:  incoming but no outgoing packets
+      dir = out: outgoing but no incoming packets
+      dir = uni: either only incoming or only outgoing packets
+      dir = bi:  both incoming and outgoing packets
+
+    NOTE:
+      dir may only appear as (1) a top-level condition,
+      or (2) a condition of a top-level AND (&)
+
+    EXAMPLE:
+      dir = uni
+      dir = in & sip = 192.168.1.34
+      dport = 22 & dir = out
+
 COMPARATIVE OPERATORS:
 
   Base    Description            Other representations

--- a/pkg/e2etest/e2e_test.go
+++ b/pkg/e2etest/e2e_test.go
@@ -306,7 +306,6 @@ func testE2E(t *testing.T, valFilterNode *node.ValFilterNode, datasets ...[]byte
 	if dir != "" {
 		tmp[3] = fmt.Sprintf("dir = %s", dir)
 	}
-
 	copy(tmp[4:], queryArgs[2:])
 	queryArgs = tmp
 	runGoQuery(t, resGoQuery, queryArgs)

--- a/pkg/e2etest/types.go
+++ b/pkg/e2etest/types.go
@@ -5,6 +5,7 @@ package e2etest
 
 import (
 	"context"
+	"github.com/els0r/goProbe/pkg/goDB/conditions/node"
 	"io/fs"
 	"os"
 	"sync"
@@ -116,7 +117,7 @@ func (m mockIfaces) NErr() (res uint64) {
 	return
 }
 
-func (m mockIfaces) BuildResults(t *testing.T, testDir string, resGoQuery *results.Result) (results.Result, []goDB.InterfaceMetadata) {
+func (m mockIfaces) BuildResults(t *testing.T, testDir string, valFilterNode *node.ValFilterNode, resGoQuery *results.Result) (results.Result, []goDB.InterfaceMetadata) {
 
 	res := results.Result{
 		Status: results.Status{
@@ -148,9 +149,10 @@ func (m mockIfaces) BuildResults(t *testing.T, testDir string, resGoQuery *resul
 				},
 				Counters: v,
 			}
-
-			res.Rows = append(res.Rows, row)
-			res.Summary.Totals = res.Summary.Totals.Add(v)
+			if valFilterNode == nil || valFilterNode.ValFilter(row.Counters) {
+				res.Rows = append(res.Rows, row)
+				res.Summary.Totals = res.Summary.Totals.Add(v)
+			}
 			ifaceMetadata[i].Counts = ifaceMetadata[i].Counts.Add(v)
 			if row.Attributes.SrcIP.Is4() && row.Attributes.DstIP.Is4() {
 				ifaceMetadata[i].Traffic.NumV4Entries++

--- a/pkg/goDB/conditions/node/filter_direction.go
+++ b/pkg/goDB/conditions/node/filter_direction.go
@@ -1,0 +1,141 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+	"github.com/els0r/goProbe/pkg/types"
+	"github.com/els0r/goProbe/pkg/types/hashmap"
+)
+
+const FilterKeywordDirection = "dir"
+const FilterKeywordNone = "none"
+
+// FilterTypeDirection denotes filters wrt. directionality of traffic
+type FilterTypeDirection string
+
+const (
+	FilterTypeDirectionIn  FilterTypeDirection = "in"
+	FilterTypeDirectionOut                     = "out"
+	FilterTypeDirectionUni                     = "uni"
+	FilterTypeDirectionBi                      = "bi"
+)
+
+// errMultipleDirectionFilterConditions indicates that
+// the specified condition contains too many traffic direction
+// filters
+var errMultipleDirectionFilterConditions = errors.New("multiple direction filters specified")
+
+var unsupportedDirectionFilterComparatorStr = "unsupported direction filter comparator: %s"
+var unsupportedDirectionFilterStr = "unsupported direction filter: %s (use one of 'in', 'out', 'uni', 'bi')"
+
+// isDirectionCondition returns an error if node represents a
+// direction filter condition, and the node itself otherwise.
+// It is used in combination with node.transform() in order
+// to ensure direction filter conditions occur only at the
+// top level of the node or the second level in case the
+// top level represents a conjunction (AND).
+func isDirectionCondition(node conditionNode) (Node, error) {
+	if node.attribute == FilterKeywordDirection {
+		return nil, errMultipleDirectionFilterConditions
+	}
+	return node, nil
+}
+
+// extractDirectionFilter returns a ValFilter if node represents a valid direction filter condition.
+// If node represents an invalid direction filter (e.g., unsupported direction filter comparator),
+// nil is returned with an error describing the invalidity reason.
+// If the node does not contain a filter condition, nil is returned without any error.
+func extractDirectionFilter(node Node) (hashmap.ValFilter, error) {
+	switch node := node.(type) {
+	case conditionNode:
+		if node.attribute != FilterKeywordDirection {
+			return nil, nil
+		}
+		if node.comparator != "=" {
+			return nil, fmt.Errorf(unsupportedDirectionFilterComparatorStr, node.comparator)
+		}
+		var filter hashmap.ValFilter
+		switch FilterTypeDirection(node.value) {
+		case FilterTypeDirectionIn:
+			filter = types.Counters.IsOnlyInbound
+		case FilterTypeDirectionOut:
+			filter = types.Counters.IsOnlyOutbound
+		case FilterTypeDirectionUni:
+			filter = types.Counters.IsUnidirectional
+		case FilterTypeDirectionBi:
+			filter = types.Counters.IsBidirectional
+		default:
+			return nil, fmt.Errorf(unsupportedDirectionFilterStr, node.value)
+		}
+		return filter, nil
+	default:
+		return nil, nil
+	}
+}
+
+// splitOffDirectionFilter splits off the traffic direction filter
+// from the node, and returns the node without the direction filter,
+// and a separate ValFilterNode representing the direction filter.
+// The direction filter placement inside the node is being validated.
+// If there is no direction filter included in node, it returns the node
+// and a ValFilterNode with FilterType FilterKeywordNone.
+func splitOffDirectionFilter(node Node) (Node, ValFilterNode, error) {
+	valFilterNode := ValFilterNode{FilterType: FilterKeywordNone}
+	switch node := node.(type) {
+	case conditionNode:
+		filter, err := extractDirectionFilter(node)
+		if err != nil {
+			return nil, valFilterNode, err
+		}
+		if filter == nil {
+			return node, valFilterNode, nil
+		}
+		valFilterNode.FilterType = FilterKeywordDirection
+		valFilterNode.conditionNode = node
+		valFilterNode.LeftNode = false
+		valFilterNode.ValFilter = filter
+		return nil, valFilterNode, errEmptyConditional
+	case andNode:
+		nodes := [2]Node{node.left, node.right}
+		filters := [2]hashmap.ValFilter{nil, nil}
+		for i := 0; i < 2; i++ {
+			n := nodes[i]
+			filter, err := extractDirectionFilter(n)
+			if err != nil {
+				continue
+			}
+			filters[i] = filter
+		}
+		// none of the two child nodes represent direction conditions
+		// => nothing to split off
+		if filters[0] == nil && filters[1] == nil {
+			return node, valFilterNode, nil
+		}
+		// both of the two child nodes represent direction conditions
+		// => invalid filter condition string
+		// e.g. "dir = in and dir = out"
+		if filters[0] != nil && filters[1] != nil {
+			return nil, valFilterNode, errMultipleDirectionFilterConditions
+		}
+
+		// check that the conjunction child node that does not represent a direction filter
+		// condition also does not contain a filtering condition at a lower level
+		// e.g. forbidden: "dir = in and ( sip = 1.2.3.4 and dir = out )"
+		i := 0
+		if filters[i] != nil {
+			i = 1
+		}
+		n := nodes[i]
+		_, err := n.transform(isDirectionCondition)
+		if err != nil {
+			return nil, valFilterNode, err
+		}
+		valFilterNode.FilterType = FilterKeywordDirection
+		valFilterNode.conditionNode = nodes[1-i].(conditionNode)
+		valFilterNode.LeftNode = i == 1
+		valFilterNode.ValFilter = filters[1-i]
+		return n, valFilterNode, nil
+	default:
+		return node, valFilterNode, nil
+	}
+}

--- a/pkg/goDB/conditions/node/filter_direction.go
+++ b/pkg/goDB/conditions/node/filter_direction.go
@@ -7,20 +7,6 @@ import (
 	"github.com/els0r/goProbe/pkg/types/hashmap"
 )
 
-// FilterTypeDirection denotes filters wrt. directionality of traffic
-type FilterTypeDirection string
-
-const (
-	filterTypeDirectionIn         FilterTypeDirection = "in"
-	filterTypeDirectionInSugared                      = "inbound"
-	filterTypeDirectionOut                            = "out"
-	filterTypeDirectionOutSugared                     = "outbound"
-	filterTypeDirectionUni                            = "uni"
-	filterTypeDirectionUniSugared                     = "unidirectional"
-	filterTypeDirectionBi                             = "bi"
-	filterTypeDirectionBiSugared                      = "bidirectional"
-)
-
 var (
 	// errMultipleDirectionFilterConditions indicates that
 	// the specified condition contains too many traffic direction
@@ -63,14 +49,14 @@ func extractDirectionFilter(node Node) (hashmap.ValFilter, error) {
 			return nil, fmt.Errorf(unsupportedDirectionFilterComparatorStr, node.comparator)
 		}
 		var filter hashmap.ValFilter
-		switch FilterTypeDirection(node.value) {
-		case filterTypeDirectionIn, filterTypeDirectionInSugared:
+		switch types.FilterTypeDirection(node.value) {
+		case types.FilterTypeDirectionIn, types.FilterTypeDirectionInSugared:
 			filter = types.Counters.IsOnlyInbound
-		case filterTypeDirectionOut, filterTypeDirectionOutSugared:
+		case types.FilterTypeDirectionOut, types.FilterTypeDirectionOutSugared:
 			filter = types.Counters.IsOnlyOutbound
-		case filterTypeDirectionUni, filterTypeDirectionUniSugared:
+		case types.FilterTypeDirectionUni, types.FilterTypeDirectionUniSugared:
 			filter = types.Counters.IsUnidirectional
-		case filterTypeDirectionBi, filterTypeDirectionBiSugared:
+		case types.FilterTypeDirectionBi, types.FilterTypeDirectionBiSugared:
 			filter = types.Counters.IsBidirectional
 		default:
 			return nil, fmt.Errorf(unsupportedDirectionFilterStr, node.value)

--- a/pkg/goDB/conditions/node/filter_direction_test.go
+++ b/pkg/goDB/conditions/node/filter_direction_test.go
@@ -1,0 +1,112 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+	"github.com/els0r/goProbe/pkg/types"
+	"github.com/els0r/goProbe/pkg/types/hashmap"
+	"reflect"
+	"testing"
+)
+
+var isDirectionConditionTest = []struct {
+	node        conditionNode
+	expectedErr error
+}{
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "in"}, expectedErr: errMultipleDirectionFilterConditions},
+	{node: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, expectedErr: nil},
+}
+
+func TestIsDirectionCondition(t *testing.T) {
+	for _, test := range isDirectionConditionTest {
+		n, err := isDirectionCondition(test.node)
+		if !errors.Is(err, test.expectedErr) {
+			t.Fatalf("Expected error: %s Actual error: %s\n", test.expectedErr, err)
+		}
+		if err == nil && n.String() != test.node.String() {
+			t.Fatalf("Expected node: %s  Returned node:%s \n", n.String(), test.node.String())
+		}
+	}
+}
+
+var extractDirectionFilterTest = []struct {
+	node           Node
+	expectedFilter hashmap.ValFilter
+	expectedErr    error
+}{
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "in"}, expectedFilter: types.Counters.IsOnlyInbound, expectedErr: nil},
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "out"}, expectedFilter: types.Counters.IsOnlyOutbound, expectedErr: nil},
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "uni"}, expectedFilter: types.Counters.IsUnidirectional, expectedErr: nil},
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "bi"}, expectedFilter: types.Counters.IsBidirectional, expectedErr: nil},
+	{node: conditionNode{attribute: "dir", comparator: "!=", value: "bi"}, expectedFilter: nil, expectedErr: fmt.Errorf(unsupportedDirectionFilterComparatorStr, "!=")},
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "unknown"}, expectedFilter: nil, expectedErr: fmt.Errorf(unsupportedDirectionFilterStr, "unknown")},
+	{node: notNode{node: conditionNode{attribute: "dir", comparator: "=", value: "unknown"}}, expectedFilter: nil, expectedErr: nil},
+}
+
+func TestExtractDirectionFilter(t *testing.T) {
+	for _, test := range extractDirectionFilterTest {
+		filter, err := extractDirectionFilter(test.node)
+		if err != nil && err.Error() != test.expectedErr.Error() {
+			t.Fatalf("Expected error: %s Actual error: %s\n", test.expectedErr, err)
+		}
+		if err == nil && reflect.ValueOf(filter) != reflect.ValueOf(test.expectedFilter) {
+			t.Fatalf("Expected filter type: %s Got: %s", reflect.TypeOf(test.expectedFilter), reflect.TypeOf(filter))
+		}
+	}
+}
+
+var splitOffDirectionFilterTest = []struct {
+	node              Node
+	expectedCondition Node
+	expectedFilter    hashmap.ValFilter
+	expectedErr       error
+}{
+	// only traffic filtering condition
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "in"}, expectedCondition: nil,
+		expectedFilter: types.Counters.IsOnlyInbound, expectedErr: errEmptyConditional},
+	// valid filter within first term of top-level conjunction
+	{node: andNode{left: conditionNode{attribute: "dir", comparator: "=", value: "out"}, right: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}},
+		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilter:    types.Counters.IsOnlyOutbound, expectedErr: nil},
+	// valid filter within second term of top-level conjunction
+	{node: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "dir", comparator: "=", value: "uni"}},
+		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilter:    types.Counters.IsUnidirectional, expectedErr: nil},
+	// invalid filter (2 traffic filters provided)
+	{node: andNode{left: conditionNode{attribute: "dir", comparator: "=", value: "uni"},
+		right: conditionNode{attribute: "dir", comparator: "=", value: "bi"}},
+		expectedCondition: nil,
+		expectedFilter:    nil, expectedErr: errMultipleDirectionFilterConditions},
+	// invalid filter (2 traffic filters provided, of which one is nested)
+	{node: andNode{left: conditionNode{attribute: "dir", comparator: "=", value: "uni"},
+		right: andNode{left: conditionNode{attribute: "dip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "dir", comparator: "=", value: "bi"}}},
+		expectedCondition: nil,
+		expectedFilter:    nil, expectedErr: errMultipleDirectionFilterConditions},
+	// simple condition without any traffic filter => valid
+	{node: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilter:    nil, expectedErr: nil},
+	// conjunctive condition without any traffic filter => valid
+	{node: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}},
+		expectedCondition: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}},
+		expectedFilter:    nil, expectedErr: nil},
+}
+
+func TestSplitOffDirectionFilter(t *testing.T) {
+	for _, test := range splitOffDirectionFilterTest {
+		condition, valFilterNode, err := splitOffDirectionFilter(test.node)
+		if err != nil && err.Error() != test.expectedErr.Error() {
+			t.Fatalf("Expected error: %s Actual error: %s\n", test.expectedErr, err)
+		}
+
+		if err == nil && reflect.ValueOf(valFilterNode.ValFilter) != reflect.ValueOf(test.expectedFilter) {
+			t.Fatalf("Expected filter type: %s Got: %s", reflect.TypeOf(test.expectedFilter), reflect.TypeOf(valFilterNode.ValFilter))
+		}
+		if err == nil && condition.String() != test.expectedCondition.String() {
+			t.Log("Incorrect split off of condition")
+			t.Logf("Expected: %s", test.expectedCondition.String())
+			t.Logf("Got: %s", condition.String())
+			t.Fatal()
+		}
+	}
+}

--- a/pkg/goDB/conditions/node/filter_direction_test.go
+++ b/pkg/goDB/conditions/node/filter_direction_test.go
@@ -1,10 +1,10 @@
 package node
 
 import (
-	"errors"
 	"fmt"
 	"github.com/els0r/goProbe/pkg/types"
 	"github.com/els0r/goProbe/pkg/types/hashmap"
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 )
@@ -20,11 +20,10 @@ var isDirectionConditionTest = []struct {
 func TestIsDirectionCondition(t *testing.T) {
 	for _, test := range isDirectionConditionTest {
 		n, err := isDirectionCondition(test.node)
-		if !errors.Is(err, test.expectedErr) {
-			t.Fatalf("Expected error: %s Actual error: %s\n", test.expectedErr, err)
-		}
-		if err == nil && n.String() != test.node.String() {
-			t.Fatalf("Expected node: %s  Returned node:%s \n", n.String(), test.node.String())
+
+		require.Equalf(t, err, test.expectedErr, "Expected error: %s Actual error: %s\n", test.expectedErr, err)
+		if err == nil {
+			require.Equalf(t, n.String(), test.node.String(), "Expected node: %s  Returned node:%s \n", n.String(), test.node.String())
 		}
 	}
 }
@@ -46,8 +45,8 @@ var extractDirectionFilterTest = []struct {
 func TestExtractDirectionFilter(t *testing.T) {
 	for _, test := range extractDirectionFilterTest {
 		filter, err := extractDirectionFilter(test.node)
-		if err != nil && err.Error() != test.expectedErr.Error() {
-			t.Fatalf("Expected error: %s Actual error: %s\n", test.expectedErr, err)
+		if err != nil {
+			require.Equalf(t, test.expectedErr, err, "Expected error: %s Actual error: %s\n", test.expectedErr, err)
 		}
 		if err == nil && reflect.ValueOf(filter) != reflect.ValueOf(test.expectedFilter) {
 			t.Fatalf("Expected filter type: %s Got: %s", reflect.TypeOf(test.expectedFilter), reflect.TypeOf(filter))
@@ -115,18 +114,16 @@ var splitOffDirectionFilterTest = []struct {
 func TestSplitOffDirectionFilter(t *testing.T) {
 	for _, test := range splitOffDirectionFilterTest {
 		condition, valFilterNode, err := splitOffDirectionFilter(test.node)
-		if err != nil && err.Error() != test.expectedErr.Error() {
-			t.Fatalf("Expected error: %s Actual error: %s\n", test.expectedErr, err)
+		if err != nil {
+			require.Equalf(t, test.expectedErr, err, "Expected error: %s Actual error: %s\n", test.expectedErr, err)
 		}
 
-		if err == nil && reflect.ValueOf(valFilterNode.ValFilter) != reflect.ValueOf(test.expectedFilter) {
-			t.Fatalf("Expected filter type: %s Got: %s", reflect.TypeOf(test.expectedFilter), reflect.TypeOf(valFilterNode.ValFilter))
-		}
-		if err == nil && condition.String() != test.expectedCondition.String() {
-			t.Log("Incorrect split off of condition")
-			t.Logf("Expected: %s", test.expectedCondition.String())
-			t.Logf("Got: %s", condition.String())
-			t.Fatal()
+		if err == nil {
+			if reflect.ValueOf(valFilterNode.ValFilter) != reflect.ValueOf(test.expectedFilter) {
+				t.Fatalf("Expected filter type: %s Got: %s", reflect.TypeOf(test.expectedFilter), reflect.TypeOf(valFilterNode.ValFilter))
+			}
+			require.Equalf(t, condition.String(), test.expectedCondition.String(), "Expected Node: %s Got %s",
+				test.expectedCondition.String(), condition.String())
 		}
 	}
 }

--- a/pkg/goDB/conditions/node/filter_direction_test.go
+++ b/pkg/goDB/conditions/node/filter_direction_test.go
@@ -40,7 +40,7 @@ var extractDirectionFilterTest = []struct {
 	{node: conditionNode{attribute: "dir", comparator: "=", value: "bi"}, expectedFilter: types.Counters.IsBidirectional, expectedErr: nil},
 	{node: conditionNode{attribute: "dir", comparator: "!=", value: "bi"}, expectedFilter: nil, expectedErr: fmt.Errorf(unsupportedDirectionFilterComparatorStr, "!=")},
 	{node: conditionNode{attribute: "dir", comparator: "=", value: "unknown"}, expectedFilter: nil, expectedErr: fmt.Errorf(unsupportedDirectionFilterStr, "unknown")},
-	{node: notNode{node: conditionNode{attribute: "dir", comparator: "=", value: "unknown"}}, expectedFilter: nil, expectedErr: nil},
+	{node: notNode{node: conditionNode{attribute: "dir", comparator: "=", value: "unknown"}}, expectedFilter: nil, expectedErr: errNoFilter},
 }
 
 func TestExtractDirectionFilter(t *testing.T) {

--- a/pkg/goDB/conditions/node/filter_direction_test.go
+++ b/pkg/goDB/conditions/node/filter_direction_test.go
@@ -2,11 +2,9 @@ package node
 
 import (
 	"fmt"
-	"github.com/els0r/goProbe/pkg/types"
-	"github.com/els0r/goProbe/pkg/types/hashmap"
-	"github.com/stretchr/testify/require"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var isDirectionConditionTest = []struct {
@@ -29,86 +27,84 @@ func TestIsDirectionCondition(t *testing.T) {
 }
 
 var extractDirectionFilterTest = []struct {
-	node           Node
-	expectedFilter hashmap.ValFilter
-	expectedErr    error
+	node        Node
+	expectedErr error
 }{
-	{node: conditionNode{attribute: "dir", comparator: "=", value: "in"}, expectedFilter: types.Counters.IsOnlyInbound, expectedErr: nil},
-	{node: conditionNode{attribute: "dir", comparator: "=", value: "out"}, expectedFilter: types.Counters.IsOnlyOutbound, expectedErr: nil},
-	{node: conditionNode{attribute: "dir", comparator: "=", value: "uni"}, expectedFilter: types.Counters.IsUnidirectional, expectedErr: nil},
-	{node: conditionNode{attribute: "dir", comparator: "=", value: "bi"}, expectedFilter: types.Counters.IsBidirectional, expectedErr: nil},
-	{node: conditionNode{attribute: "dir", comparator: "!=", value: "bi"}, expectedFilter: nil, expectedErr: fmt.Errorf(unsupportedDirectionFilterComparatorStr, "!=")},
-	{node: conditionNode{attribute: "dir", comparator: "=", value: "unknown"}, expectedFilter: nil, expectedErr: fmt.Errorf(unsupportedDirectionFilterStr, "unknown")},
-	{node: notNode{node: conditionNode{attribute: "dir", comparator: "=", value: "unknown"}}, expectedFilter: nil, expectedErr: errNoFilter},
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "in"}, expectedErr: nil},
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "out"}, expectedErr: nil},
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "uni"}, expectedErr: nil},
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "bi"}, expectedErr: nil},
+	{node: conditionNode{attribute: "dir", comparator: "!=", value: "bi"}, expectedErr: fmt.Errorf(unsupportedDirectionFilterComparatorStr, "!=")},
+	{node: conditionNode{attribute: "dir", comparator: "=", value: "unknown"}, expectedErr: fmt.Errorf(unsupportedDirectionFilterStr, "unknown")},
+	{node: notNode{node: conditionNode{attribute: "dir", comparator: "=", value: "unknown"}}, expectedErr: errNoFilter},
 }
 
 func TestExtractDirectionFilter(t *testing.T) {
 	for _, test := range extractDirectionFilterTest {
-		filter, err := extractDirectionFilter(test.node)
+		_, err := extractDirectionFilter(test.node)
 		if err != nil {
 			require.Equalf(t, test.expectedErr, err, "Expected error: %s Actual error: %s\n", test.expectedErr, err)
-		}
-		if err == nil && reflect.ValueOf(filter) != reflect.ValueOf(test.expectedFilter) {
-			t.Fatalf("Expected filter type: %s Got: %s", reflect.TypeOf(test.expectedFilter), reflect.TypeOf(filter))
 		}
 	}
 }
 
+const conditionNone = "  "
+
 var splitOffDirectionFilterTest = []struct {
-	node              Node
-	expectedCondition Node
-	expectedFilter    hashmap.ValFilter
-	expectedErr       error
+	node                    Node
+	expectedCondition       Node
+	expectedFilterCondition string
+	expectedErr             error
 }{
 	// only traffic filtering condition
 	{node: conditionNode{attribute: "dir", comparator: "=", value: "in"}, expectedCondition: nil,
-		expectedFilter: types.Counters.IsOnlyInbound, expectedErr: errEmptyConditional},
+		expectedFilterCondition: "dir = in", expectedErr: errEmptyConditional},
 	{node: conditionNode{attribute: "direction", comparator: "=", value: "inbound"}, expectedCondition: nil,
-		expectedFilter: types.Counters.IsOnlyInbound, expectedErr: errEmptyConditional},
+		expectedFilterCondition: "dir = inbound", expectedErr: errEmptyConditional},
 	// valid filter within first term of top-level conjunction
 	{node: andNode{left: conditionNode{attribute: "dir", comparator: "=", value: "out"}, right: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}},
-		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
-		expectedFilter:    types.Counters.IsOnlyOutbound, expectedErr: nil},
+		expectedCondition:       conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilterCondition: "dir = out", expectedErr: nil},
 	{node: andNode{left: conditionNode{attribute: "direction", comparator: "=", value: "outbound"}, right: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}},
-		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
-		expectedFilter:    types.Counters.IsOnlyOutbound, expectedErr: nil},
+		expectedCondition:       conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilterCondition: "direction = outbound", expectedErr: nil},
 	// valid filter within second term of top-level conjunction
 	{node: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "dir", comparator: "=", value: "uni"}},
-		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
-		expectedFilter:    types.Counters.IsUnidirectional, expectedErr: nil},
+		expectedCondition:       conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilterCondition: "dir = uni", expectedErr: nil},
 	{node: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "dir", comparator: "=", value: "unidirectional"}},
-		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
-		expectedFilter:    types.Counters.IsUnidirectional, expectedErr: nil},
+		expectedCondition:       conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilterCondition: "dir = unidirectional", expectedErr: nil},
 	{node: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "dir", comparator: "=", value: "bidirectional"}},
-		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
-		expectedFilter:    types.Counters.IsBidirectional, expectedErr: nil},
+		expectedCondition:       conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilterCondition: "dir = bidirectional", expectedErr: nil},
 	// invalid filter (2 traffic filters provided)
 	{node: andNode{left: conditionNode{attribute: "dir", comparator: "=", value: "uni"},
 		right: conditionNode{attribute: "dir", comparator: "=", value: "bi"}},
-		expectedCondition: nil,
-		expectedFilter:    nil, expectedErr: errMultipleDirectionFilterConditions},
+		expectedCondition:       nil,
+		expectedFilterCondition: "", expectedErr: errMultipleDirectionFilterConditions},
 	// invalid filter (2 traffic filters provided, of which one is nested)
 	{node: andNode{left: conditionNode{attribute: "dir", comparator: "=", value: "uni"},
 		right: andNode{left: conditionNode{attribute: "dip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "dir", comparator: "=", value: "bi"}}},
-		expectedCondition: nil,
-		expectedFilter:    nil, expectedErr: errMultipleDirectionFilterConditions},
+		expectedCondition:       nil,
+		expectedFilterCondition: "", expectedErr: errMultipleDirectionFilterConditions},
 	// simple condition without any traffic filter => valid
 	{node: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
-		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
-		expectedFilter:    nil, expectedErr: nil},
+		expectedCondition:       conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilterCondition: conditionNone, expectedErr: nil},
 	// disjunctive condition with traffic filter => invalid
 	{node: orNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "dir", comparator: "=", value: "in"}},
-		expectedCondition: nil,
-		expectedFilter:    nil, expectedErr: errMisplacedDirectionFilterCondition},
+		expectedCondition:       nil,
+		expectedFilterCondition: "", expectedErr: errMisplacedDirectionFilterCondition},
 	// conjunctive condition without any traffic filter => valid
 	{node: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}},
-		expectedCondition: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}},
-		expectedFilter:    nil, expectedErr: nil},
+		expectedCondition:       andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}},
+		expectedFilterCondition: conditionNone, expectedErr: nil},
 	// conjunctive condition with misplaced traffic filter => invalid
 	{node: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
 		right: orNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "dir", comparator: "=", value: "in"}}},
-		expectedCondition: nil,
-		expectedFilter:    nil, expectedErr: errMisplacedDirectionFilterCondition},
+		expectedCondition:       nil,
+		expectedFilterCondition: "", expectedErr: errMisplacedDirectionFilterCondition},
 }
 
 func TestSplitOffDirectionFilter(t *testing.T) {
@@ -117,10 +113,9 @@ func TestSplitOffDirectionFilter(t *testing.T) {
 		if err != nil {
 			require.Equalf(t, test.expectedErr, err, "Expected error: %s Actual error: %s\n", test.expectedErr, err)
 		}
-
 		if err == nil {
-			if reflect.ValueOf(valFilterNode.ValFilter) != reflect.ValueOf(test.expectedFilter) {
-				t.Fatalf("Expected filter type: %s Got: %s", reflect.TypeOf(test.expectedFilter), reflect.TypeOf(valFilterNode.ValFilter))
+			if valFilterNode.String() != test.expectedFilterCondition {
+				t.Fatalf("Expected filter type: %s Got: %s", test.expectedFilterCondition, valFilterNode.String())
 			}
 			require.Equalf(t, condition.String(), test.expectedCondition.String(), "Expected Node: %s Got %s",
 				test.expectedCondition.String(), condition.String())

--- a/pkg/goDB/conditions/node/filter_direction_test.go
+++ b/pkg/goDB/conditions/node/filter_direction_test.go
@@ -64,14 +64,25 @@ var splitOffDirectionFilterTest = []struct {
 	// only traffic filtering condition
 	{node: conditionNode{attribute: "dir", comparator: "=", value: "in"}, expectedCondition: nil,
 		expectedFilter: types.Counters.IsOnlyInbound, expectedErr: errEmptyConditional},
+	{node: conditionNode{attribute: "direction", comparator: "=", value: "inbound"}, expectedCondition: nil,
+		expectedFilter: types.Counters.IsOnlyInbound, expectedErr: errEmptyConditional},
 	// valid filter within first term of top-level conjunction
 	{node: andNode{left: conditionNode{attribute: "dir", comparator: "=", value: "out"}, right: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}},
+		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilter:    types.Counters.IsOnlyOutbound, expectedErr: nil},
+	{node: andNode{left: conditionNode{attribute: "direction", comparator: "=", value: "outbound"}, right: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}},
 		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
 		expectedFilter:    types.Counters.IsOnlyOutbound, expectedErr: nil},
 	// valid filter within second term of top-level conjunction
 	{node: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "dir", comparator: "=", value: "uni"}},
 		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
 		expectedFilter:    types.Counters.IsUnidirectional, expectedErr: nil},
+	{node: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "dir", comparator: "=", value: "unidirectional"}},
+		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilter:    types.Counters.IsUnidirectional, expectedErr: nil},
+	{node: andNode{left: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, right: conditionNode{attribute: "dir", comparator: "=", value: "bidirectional"}},
+		expectedCondition: conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		expectedFilter:    types.Counters.IsBidirectional, expectedErr: nil},
 	// invalid filter (2 traffic filters provided)
 	{node: andNode{left: conditionNode{attribute: "dir", comparator: "=", value: "uni"},
 		right: conditionNode{attribute: "dir", comparator: "=", value: "bi"}},

--- a/pkg/goDB/conditions/node/node.go
+++ b/pkg/goDB/conditions/node/node.go
@@ -242,7 +242,7 @@ type ValFilterNode struct {
 // "Conditions" output field based on the query conditions and the query filter
 func QueryConditionalString(conditionalNode Node, filterNode Node) string {
 	valFilterNode, ok := filterNode.(*ValFilterNode)
-	if !ok || valFilterNode.FilterType == FilterKeywordNone {
+	if !ok || valFilterNode.FilterType == types.FilterKeywordNone {
 		if conditionalNode == nil {
 			return ""
 		}

--- a/pkg/goDB/conditions/node/node.go
+++ b/pkg/goDB/conditions/node/node.go
@@ -238,6 +238,14 @@ type ValFilterNode struct {
 	LeftNode   bool
 }
 
+func (filter *ValFilterNode) setValFilterValues(cn conditionNode, ft string,
+	vf hashmap.ValFilter, ln bool) {
+	filter.conditionNode = cn
+	filter.FilterType = ft
+	filter.ValFilter = vf
+	filter.LeftNode = ln
+}
+
 // QueryConditionalString constructs the conditional string shown in the
 // "Conditions" output field based on the query conditions and the query filter
 func QueryConditionalString(conditionalNode Node, filterNode Node) string {

--- a/pkg/goDB/conditions/node/node.go
+++ b/pkg/goDB/conditions/node/node.go
@@ -23,6 +23,7 @@ package node
 import (
 	"errors"
 	"fmt"
+	"github.com/els0r/goProbe/pkg/types/hashmap"
 	"time"
 
 	"github.com/els0r/goProbe/pkg/goDB/conditions"
@@ -33,34 +34,38 @@ const resNil = "<nil>"
 
 // ParseAndInstrument parses and instruments the given conditional string for evaluation.
 // This is the main external function related to conditionals.
-func ParseAndInstrument(conditional string, dnsTimeout time.Duration) (Node, error) {
+func ParseAndInstrument(conditional string, dnsTimeout time.Duration) (Node, *ValFilterNode, error) {
 	tokens, err := conditions.Tokenize(conditional)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	conditionalNode, err := parseConditional(tokens)
 	if err != nil && !errors.Is(err, errEmptyConditional) {
-		return nil, err
+		return nil, nil, err
+	}
+	conditionalNode, valFilterNode, err := splitOffDirectionFilter(conditionalNode)
+	if err != nil && !errors.Is(err, errEmptyConditional) {
+		return nil, nil, err
 	}
 
 	if conditionalNode != nil {
 		if conditionalNode, err = desugar(conditionalNode); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		if conditionalNode, err = resolve(conditionalNode, dnsTimeout); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		conditionalNode = negationNormalForm(conditionalNode)
 
 		if conditionalNode, err = instrument(conditionalNode); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return conditionalNode, nil
+	return conditionalNode, &valFilterNode, nil
 }
 
 // Node describes an AST node for the conditional grammar
@@ -220,6 +225,39 @@ func (n orNode) Attributes() map[string]types.IPVersion {
 		result[attribute] = result[attribute].Merge(ipVersion)
 	}
 	return result
+}
+
+// ValFilterNode describes a node representing a ValFilter.
+// LeftNode is true if the ValFilterNode occurs on the left side
+// of a conjunction (andNode) and false if it occurs on the
+// right side.
+type ValFilterNode struct {
+	conditionNode
+	FilterType string
+	ValFilter  hashmap.ValFilter
+	LeftNode   bool
+}
+
+// QueryConditionalString constructs the conditional string shown in the
+// "Conditions" output field based on the query conditions and the query filter
+func QueryConditionalString(conditionalNode Node, filterNode Node) string {
+	valFilterNode, ok := filterNode.(*ValFilterNode)
+	if !ok || valFilterNode.FilterType == FilterKeywordNone {
+		if conditionalNode == nil {
+			return ""
+		}
+		return conditionalNode.String()
+	}
+	if conditionalNode == nil {
+		return valFilterNode.String()
+	}
+	var n andNode
+	if valFilterNode.LeftNode {
+		n = andNode{left: valFilterNode.conditionNode, right: conditionalNode}
+	} else {
+		n = andNode{left: conditionalNode, right: valFilterNode.conditionNode}
+	}
+	return n.String()
 }
 
 // Brings a conditional ast tree into negation normal form.

--- a/pkg/goDB/conditions/node/node_test.go
+++ b/pkg/goDB/conditions/node/node_test.go
@@ -114,13 +114,13 @@ var queryConditionalStringTests = []struct {
 	expected        string
 }{
 	{nil, nil, ""},
-	{nil, &ValFilterNode{FilterType: FilterKeywordNone}, ""},
+	{nil, &ValFilterNode{FilterType: types.FilterKeywordNone}, ""},
 	{conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, nil, "sip = 127.0.0.1"},
 	{conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
-		&ValFilterNode{conditionNode: conditionNode{attribute: FilterKeywordDirection, comparator: "=", value: "in"}, FilterType: FilterKeywordDirection, ValFilter: types.Counters.IsOnlyInbound, LeftNode: true},
+		&ValFilterNode{conditionNode: conditionNode{attribute: types.FilterKeywordDirection, comparator: "=", value: "in"}, FilterType: types.FilterKeywordDirection, ValFilter: types.Counters.IsOnlyInbound, LeftNode: true},
 		"(dir = in & sip = 127.0.0.1)"},
 	{conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
-		&ValFilterNode{conditionNode: conditionNode{attribute: FilterKeywordDirection, comparator: "=", value: "in"}, FilterType: FilterKeywordDirection, ValFilter: types.Counters.IsOnlyInbound, LeftNode: false},
+		&ValFilterNode{conditionNode: conditionNode{attribute: types.FilterKeywordDirection, comparator: "=", value: "in"}, FilterType: types.FilterKeywordDirection, ValFilter: types.Counters.IsOnlyInbound, LeftNode: false},
 		"(sip = 127.0.0.1 & dir = in)"},
 }
 

--- a/pkg/goDB/conditions/node/node_test.go
+++ b/pkg/goDB/conditions/node/node_test.go
@@ -14,6 +14,7 @@ package node
 import (
 	"errors"
 	"fmt"
+	"github.com/els0r/goProbe/pkg/types"
 	"testing"
 )
 
@@ -103,6 +104,30 @@ func TestListToTree(t *testing.T) {
 		}
 		if !checkNoPointer(node) {
 			t.Fatalf("testcase: %v andflag: %v contains pointers somewhere in the tree", test.inNodes, test.and)
+		}
+	}
+}
+
+var queryConditionalStringTests = []struct {
+	conditionalNode Node
+	filterNode      Node
+	expected        string
+}{
+	{nil, nil, ""},
+	{nil, &ValFilterNode{FilterType: FilterKeywordNone}, ""},
+	{conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"}, nil, "sip = 127.0.0.1"},
+	{conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		&ValFilterNode{conditionNode: conditionNode{attribute: FilterKeywordDirection, comparator: "=", value: "in"}, FilterType: FilterKeywordDirection, ValFilter: types.Counters.IsOnlyInbound, LeftNode: true},
+		"(dir = in & sip = 127.0.0.1)"},
+	{conditionNode{attribute: "sip", comparator: "=", value: "127.0.0.1"},
+		&ValFilterNode{conditionNode: conditionNode{attribute: FilterKeywordDirection, comparator: "=", value: "in"}, FilterType: FilterKeywordDirection, ValFilter: types.Counters.IsOnlyInbound, LeftNode: false},
+		"(sip = 127.0.0.1 & dir = in)"},
+}
+
+func TestQueryConditionalString(t *testing.T) {
+	for _, test := range queryConditionalStringTests {
+		if got := QueryConditionalString(test.conditionalNode, test.filterNode); test.expected != got {
+			t.Fatalf("Expected: %s Got: %s", test.expected, got)
 		}
 	}
 }

--- a/pkg/goDB/conditions/node/parse.go
+++ b/pkg/goDB/conditions/node/parse.go
@@ -318,7 +318,7 @@ func (p *parser) condition() (result Node) {
 // Corresponds to grammar rule "attribute"
 func (p *parser) attribute() (result string) {
 	attributes := []string{
-		types.DIPName, types.SIPName, "dnet", "snet", types.DportName, types.ProtoName, // non-sugar
+		types.DIPName, types.SIPName, "dnet", "snet", types.DportName, types.ProtoName, FilterKeywordDirection, // non-sugar
 		"dst", "src", "host", "net", "port", "protocol", "ipproto", // sugar
 	}
 	for _, attrib := range attributes {

--- a/pkg/goDB/conditions/node/parse.go
+++ b/pkg/goDB/conditions/node/parse.go
@@ -318,8 +318,8 @@ func (p *parser) condition() (result Node) {
 // Corresponds to grammar rule "attribute"
 func (p *parser) attribute() (result string) {
 	attributes := []string{
-		types.DIPName, types.SIPName, "dnet", "snet", types.DportName, types.ProtoName, FilterKeywordDirection, // non-sugar
-		"dst", "src", "host", "net", "port", "protocol", "ipproto", // sugar
+		types.DIPName, types.SIPName, "dnet", "snet", types.DportName, types.ProtoName, types.FilterKeywordDirection, // non-sugar
+		"dst", "src", "host", "net", "port", "protocol", "ipproto", types.FilterKeywordDirectionSugared, // sugar
 	}
 	for _, attrib := range attributes {
 		if p.accept(attrib) {

--- a/pkg/goDB/conditions/node/parse_test.go
+++ b/pkg/goDB/conditions/node/parse_test.go
@@ -42,6 +42,15 @@ var parseConditionalTests = []struct {
 	{[]string{"sip", "=", "192.168.1.1", "|", "sip", "=", "192.168.1.2", "|", "sip", "=", "192.168.1.3", "|", "sip", "=", "192.168.1.4"},
 		"(sip = 192.168.1.1 | (sip = 192.168.1.2 | (sip = 192.168.1.3 | sip = 192.168.1.4)))",
 		true},
+	{[]string{"dir", "=", "in"},
+		"dir = in",
+		true},
+	{[]string{"direction", "=", "in"},
+		"direction = in",
+		true},
+	{[]string{"directio", "=", "in"},
+		"direction = in",
+		false},
 }
 
 func TestParseConditional(t *testing.T) {

--- a/pkg/goDB/engine/aggregate.go
+++ b/pkg/goDB/engine/aggregate.go
@@ -67,8 +67,8 @@ func aggregate(mapChan <-chan hashmap.AggFlowMapWithMetadata, ifaces []string, i
 
 			finalMap := finalMaps[item.Interface]
 
-			// Merge the item into the final map for this interface, then update the aggregation counter
-			finalMap.Merge(item, &totals)
+			// Merge the item into the final map for this interface
+			finalMap.Merge(item)
 			nAgg[item.Interface] = nAgg[item.Interface] + 1
 
 			// Cleanup the now unused item / map

--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -236,10 +236,8 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 	}
 	var totals hashmap.Val
 	for iface, aggMap := range agg.aggregatedMaps {
-		var i *hashmap.MetaIter
-		if metaIterOption == nil {
-			i = aggMap.Iter()
-		} else {
+		var i = aggMap.Iter()
+		if metaIterOption != nil {
 			i = aggMap.Iter(metaIterOption)
 		}
 		for i.Next() {

--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -230,7 +230,7 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 	var rs = make(results.Rows, agg.aggregatedMaps.Len())
 	count := 0
 
-	var metaIterOption hashmap.MetaIterOption = nil
+	var metaIterOption hashmap.MetaIterOption
 	if valFilterNode != nil && valFilterNode.ValFilter != nil {
 		metaIterOption = hashmap.WithFilter(valFilterNode.ValFilter)
 	}

--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -86,7 +86,7 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 	}
 
 	// build condition tree to check if there is a syntax error before starting processing
-	queryConditional, parseErr := node.ParseAndInstrument(stmt.Condition, stmt.DNSResolution.Timeout)
+	queryConditional, valFilterNode, parseErr := node.ParseAndInstrument(stmt.Condition, stmt.DNSResolution.Timeout)
 	if parseErr != nil {
 		return res, fmt.Errorf("conditions parsing error: %w", parseErr)
 	}
@@ -99,9 +99,7 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 	result.Query = results.Query{
 		Attributes: qr.query.AttributesToString(),
 	}
-	if qr.query.Conditional != nil {
-		result.Query.Condition = qr.query.Conditional.String()
-	}
+	result.Query.Condition = node.QueryConditionalString(qr.query.Conditional, valFilterNode)
 
 	// get hostname and host ID if available
 	hostname, err := os.Hostname()
@@ -152,13 +150,6 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 			return
 		}
 	}()
-
-	result.Query = results.Query{
-		Attributes: qr.query.AttributesToString(),
-	}
-	if qr.query.Conditional != nil {
-		result.Query.Condition = qr.query.Conditional.String()
-	}
 
 	// create work managers
 	workManagers := map[string]*goDB.DBWorkManager{} // map interfaces to workManagers
@@ -239,12 +230,23 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 	var rs = make(results.Rows, agg.aggregatedMaps.Len())
 	count := 0
 
+	var metaIterOption hashmap.MetaIterOption = nil
+	if valFilterNode != nil && valFilterNode.ValFilter != nil {
+		metaIterOption = hashmap.WithFilter(valFilterNode.ValFilter)
+	}
+	var totals hashmap.Val
 	for iface, aggMap := range agg.aggregatedMaps {
-		for i := aggMap.Iter(); i.Next(); {
+		var i *hashmap.MetaIter
+		if metaIterOption == nil {
+			i = aggMap.Iter()
+		} else {
+			i = aggMap.Iter(metaIterOption)
+		}
+		for i.Next() {
 
 			key := types.ExtendedKey(i.Key())
 			val := i.Val()
-
+			totals = totals.Add(val)
 			if ts, hasTS := key.AttrTime(); hasTS {
 				rs[count].Labels.Timestamp = time.Unix(ts, 0)
 			}
@@ -282,20 +284,25 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 		runtime.GC()
 	}
 
-	result.Summary.Totals = agg.totals
+	result.Summary.Totals = totals
 
 	// sort the results
 	results.By(stmt.SortBy, stmt.Direction, stmt.SortAscending).Sort(rs)
 
 	// stop timing everything related to the query and store the hits
-	result.Summary.Hits.Total = len(rs)
+	result.Summary.Hits.Total = count
 
-	if stmt.NumResults < uint64(len(rs)) {
-		rs = rs[:stmt.NumResults]
+	// due to filtering, might display less than min(stmt.NumResults, len(rs))
+	// result rows
+	nDisplay := stmt.NumResults
+	if uint64(count) < stmt.NumResults {
+		nDisplay = uint64(count)
+	}
+	if nDisplay < uint64(len(rs)) {
+		rs = rs[:nDisplay]
 	}
 	result.Summary.Hits.Displayed = len(rs)
 	result.Rows = rs
-
 	return result, nil
 }
 

--- a/pkg/types/hashmap/aggregate.go
+++ b/pkg/types/hashmap/aggregate.go
@@ -153,18 +153,16 @@ func (a AggFlowMap) SetOrUpdate(key Key, isIPv4 bool, eA, eB, eC, eD uint64) {
 	}
 }
 
-// Merge allows to incorporate the content of a map b into an existing map a (providing
-// additional in-place counter updates).
-func (a AggFlowMap) Merge(b AggFlowMap, totals *Val) {
-	a.PrimaryMap.Merge(b.PrimaryMap, totals)
-	a.SecondaryMap.Merge(b.SecondaryMap, totals)
+// Merge allows to incorporate the content of a map b into an existing map a
+func (a AggFlowMap) Merge(b AggFlowMap) {
+	a.PrimaryMap.Merge(b.PrimaryMap)
+	a.SecondaryMap.Merge(b.SecondaryMap)
 }
 
-// Merge allows to incorporate the content of a map b into an existing map a (providing
-// additional in-place counter updates).
-func (a AggFlowMapWithMetadata) Merge(b AggFlowMapWithMetadata, totals *Val) {
-	a.PrimaryMap.Merge(b.PrimaryMap, totals)
-	a.SecondaryMap.Merge(b.SecondaryMap, totals)
+// Merge allows to incorporate the content of a map b into an existing map a
+func (a AggFlowMapWithMetadata) Merge(b AggFlowMapWithMetadata) {
+	a.PrimaryMap.Merge(b.PrimaryMap)
+	a.SecondaryMap.Merge(b.SecondaryMap)
 }
 
 // Clear frees as many resources as possible by making them eligible for GC

--- a/pkg/types/hashmap/hashmap.go
+++ b/pkg/types/hashmap/hashmap.go
@@ -283,7 +283,7 @@ done:
 // Merge allows to incorporate the content of a map m2 into an existing map m (providing
 // additional in-place counter updates). It re-uses / duplicates code from the iterator
 // part to minimize function call overhead and allocations
-func (m *Map) Merge(m2 *Map, totals *Val) {
+func (m *Map) Merge(m2 *Map) {
 
 	if m2.Len() == 0 {
 		return
@@ -362,9 +362,6 @@ next:
 
 		val := it.val
 		m.SetOrUpdate(it.key, val.BytesRcvd, val.BytesSent, val.PacketsRcvd, val.PacketsSent)
-		if totals != nil {
-			*totals = totals.Add(val)
-		}
 
 		goto start
 	}

--- a/pkg/types/hashmap/hashmap_test.go
+++ b/pkg/types/hashmap/hashmap_test.go
@@ -207,16 +207,15 @@ func TestMerge(t *testing.T) {
 
 	var (
 		mergeMap = New()
-		totals   Val
 	)
 
-	mergeMap.Merge(testMap, &totals)
+	mergeMap.Merge(testMap)
 
 	require.Equal(t, testMap.Len(), mergeMap.Len())
 	require.Equal(t, 100000, testMap.Len())
 	require.Equal(t, 60000, testMap2.Len())
 
-	mergeMap.Merge(testMap2, &totals)
+	mergeMap.Merge(testMap2)
 
 	require.Equal(t, 110000, mergeMap.Len())
 	require.Equal(t, 100000, testMap.Len())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -106,6 +106,28 @@ const (
 	FilterKeywordNone             = "none"
 )
 
+// FilterTypeDirection denotes filters wrt. directionality of traffic
+type FilterTypeDirection string
+
+const (
+	// incoming but no outgoing packets
+	FilterTypeDirectionIn        FilterTypeDirection = "in"
+	FilterTypeDirectionInSugared FilterTypeDirection = "inbound"
+	// outgoing but no incoming packets
+	FilterTypeDirectionOut        FilterTypeDirection = "out"
+	FilterTypeDirectionOutSugared FilterTypeDirection = "outbound"
+	// either only incoming or only outgoing packets
+	FilterTypeDirectionUni        FilterTypeDirection = "uni"
+	FilterTypeDirectionUniSugared FilterTypeDirection = "unidirectional"
+	// both incoming and outgoing packets (excluding unidirectional traffic)
+	FilterTypeDirectionBi        FilterTypeDirection = "bi"
+	FilterTypeDirectionBiSugared FilterTypeDirection = "bidirectional"
+)
+
+var DirectionFilters = []FilterTypeDirection{FilterTypeDirectionIn, FilterTypeDirectionInSugared,
+	FilterTypeDirectionOut, FilterTypeDirectionOutSugared, FilterTypeDirectionOutSugared,
+	FilterTypeDirectionUni, FilterTypeDirectionUniSugared, FilterTypeDirectionBi, FilterTypeDirectionBiSugared}
+
 // AnySelector denotes any / all (interfaces, hosts, ...)
 const AnySelector = "any"
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -99,6 +99,13 @@ const (
 	KeyWidthIPv6 = sipDipIPv6Width + nonIPKeysWidth
 )
 
+// Filter-specific keywords
+const (
+	FilterKeywordDirection        = "dir"
+	FilterKeywordDirectionSugared = "direction"
+	FilterKeywordNone             = "none"
+)
+
 // AnySelector denotes any / all (interfaces, hosts, ...)
 const AnySelector = "any"
 


### PR DESCRIPTION
This PR provides support for traffic direction filters within the `-c` argument of `goQuery`.
The following direction filters are supported: 
`{dir|direction} = {in|inbound|out|outbound|uni|unidirectional|bi|bidirectional}`

A traffic direction filter is allowed to occur as:
- a top-level condition (e.g. `-c "dir = in"`)
- a condition of a top-level conjunct (e.g. `-c "(sip = 127.0.0.1 & port = 22) & dir = out"`)