### PR TITLE
[bugfix] Fix --stored-query parameter in goQuery and accept stdin

### DIFF
--- a/cmd/goQuery/cmd/root.go
+++ b/cmd/goQuery/cmd/root.go
@@ -251,9 +251,8 @@ func entrypoint(cmd *cobra.Command, args []string) (err error) {
 	if argsLocation != "" {
 		var argsReader io.Reader
 
-		if argsLocation == "-" {
-			argsReader = os.Stdin
-		} else {
+		argsReader = os.Stdin
+		if argsLocation != "-" {
 			f, err := os.Open(filepath.Clean(argsLocation))
 			if err != nil {
 				return fmt.Errorf("failed to open query args from %s: %w", argsLocation, err)


### PR DESCRIPTION
When running a query with `--stored-query` from disk, the argument for the location of the query args wasn't taken into account, rendering the flag unusable.

This commit fixes the parameter and extends functionality: in line with other tooling, if `-` is provided as the location of the query args, `goQuery` assumes that they are read from `stdin`. Thus, arguments can now be piped into `goQuery`.

Only to be merged after #234 is on main.