### PR TITLE
[feature] Add flow map volume/packets metrics to goProbe and introduce iface label

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/devcontainers/go:1.21-bullseye
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install git \
+    build-essential \
+    curl
+
+# compression libs
+RUN apt install liblz4-dev libzstd-dev
+
+# convenience tools
+RUN apt install -y vim inetutils-ping
+
+# for goProbe's info tests
+RUN mkdir -p /var/lib/dbus/ && echo "da314207b73d8b1bdeb86e5adfa0d6cb" > /var/lib/dbus/machine-id
+
+# go
+USER vscode
+RUN go install golang.org/x/tools/gopls@latest
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,69 @@
+{
+  "name": "goprobe-dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "HTTP_PROXY": "${localEnv:HTTP_PROXY}",
+      "HTTPS_PROXY": "${localEnv:HTTP_PROXY}",
+      "http_proxy": "${localEnv:HTTP_PROXY}",
+      "https_proxy": "${localEnv:HTTP_PROXY}"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "eamodio.gitlens",
+        "davidanson.vscode-markdownlint",
+        "ms-azuretools.vscode-docker",
+        "shardulm94.trailing-spaces",
+        "Gruntfuggly.todo-tree",
+        "bierner.emojisense",
+        "stkb.rewrap",
+        "vscode-icons-team.vscode-icons",
+        "github.vscode-pull-request-github",
+        "redhat.vscode-yaml",
+        "IBM.output-colorizer",
+        "github.copilot"
+      ],
+      "settings": {
+        "files.eol": "\n",
+        "editor.formatOnSave": true,
+        "go.buildTags": "",
+        "go.toolsEnvVars": {
+          "CGO_ENABLED": "0"
+        },
+        "go.useLanguageServer": true,
+        "go.testEnvVars": {
+          "CGO_ENABLED": "1"
+        },
+        "go.testFlags": [
+          "-v",
+          "-race"
+        ],
+        "go.testTimeout": "10s",
+        "go.coverOnSingleTest": true,
+        "go.coverOnSingleTestFile": true,
+        "go.coverOnTestPackage": true,
+        "go.lintTool": "golangci-lint",
+        "go.lintOnSave": "package",
+        "[go]": {
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+          }
+        },
+        "gopls": {
+          "usePlaceholders": false,
+          "staticcheck": true,
+          "vulncheck": "Imports"
+        },
+        "remote.extensionKind": {
+          "ms-azuretools.vscode-docker": "workspace"
+        }
+      }
+    }
+  },
+  "forwardPorts": [
+    8145
+  ]
+}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,15 +23,6 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
 
-    - name: Build for AMD64
-      run: GOOS=linux GOARCH=amd64 go build -tags jsoniter -v -a ./...
-
-    - name: Build for AMD64 (No-GCO Mode)
-      run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags jsoniter -v -a ./...
-
-    - name: Build for AMD64 (Production Mode)
-      run: GOOS=linux GOARCH=amd64 go build -tags jsoniter,slimcap_nomock -v -a ./...
-
     - name: Test
       run: |
         go test -tags jsoniter -v ./... -covermode=atomic -coverprofile=coverage.out
@@ -48,3 +39,12 @@ jobs:
     - name: Race Detector
       run: |
         go test -tags jsoniter -race -v ./...
+
+    - name: Build for AMD64
+      run: GOOS=linux GOARCH=amd64 go build -tags jsoniter -v -a ./...
+
+    - name: Build for AMD64 (Production Mode)
+      run: GOOS=linux GOARCH=amd64 go build -tags jsoniter,slimcap_nomock -v -a ./...
+
+    - name: Build for AMD64 (No-GCO Mode)
+      run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags jsoniter -v -a ./...

--- a/examples/config/goprobe-example-config-devcontainer.yaml
+++ b/examples/config/goprobe-example-config-devcontainer.yaml
@@ -17,7 +17,7 @@ interfaces:
   eth0:
     # promisc runs capturing in promiscuous mode in order to also capture
     # VLAN traffic
-    promisc: true
+    promisc: false
     # ring_buffer configures the ring buffer that the kernel has available
     # to populate with packet metadata. The sizing of the ring_buffer has
     # a direct effect on goprobe's base memory consumption
@@ -44,7 +44,7 @@ interfaces:
 api:
   # addr defines what the API server binds to. This may also be a unix
   # socket.
-  addr: "unix:/var/run/goprobe"
+  addr: 0.0.0.0:8145
   # profiling is enabled by default. It will only be run if one of the
   # /debug/pprof endpoints is accessed and otherwise will not have an impact
   # on performance.
@@ -56,9 +56,9 @@ api:
 # logging sets the logging parameters for goprobe
 logging:
   # level info is set not to spam the logs with writeout information for interfaces
-  level: info
+  level: debug
   # encoding logfmt is chosen over json for readability reasons
   encoding: logfmt
   # destination describes the file goprobe logs to. If left empty, goprobe will log
   # to stdout by default
-  destination: /var/logs/goprobe.log
+  destination: stdout

--- a/examples/config/goprobe-example-config-devcontainer.yaml
+++ b/examples/config/goprobe-example-config-devcontainer.yaml
@@ -12,7 +12,7 @@ interfaces:
       block_size: 1048576
 api:
   addr: 0.0.0.0:8145
-    profiling: true
+  profiling: true
   metrics: true
 logging:
   level: debug

--- a/examples/config/goprobe-example-config-devcontainer.yaml
+++ b/examples/config/goprobe-example-config-devcontainer.yaml
@@ -1,64 +1,19 @@
 ---
-# This file describes the necessary configuration defaults to run
-# goprobe v4 and its associated CLI tools goquery and gpctl
 db:
-  # path of the goDB database written by goprobe and read by goquery
   path: /usr/local/goProbe/db
-# local_buffers sets the local buffer configuration used during rotation of a capture
 local_buffers:
-  # size_limit is the buffer held for packet capture during flow rotation
-  # the unit is bytes
   size_limit: 67108864
-  # num_buffers denotes the number of buffers (and hence maximum concurrency of Status() calls)
-  # NOTE: do not change unless absolutely necessary
   num_buffers: 1
-# interfaces stores the configuration for the interfaces that goprobe will capture on
 interfaces:
   eth0:
-    # promisc runs capturing in promiscuous mode in order to also capture
-    # VLAN traffic
     promisc: false
-    # ring_buffer configures the ring buffer that the kernel has available
-    # to populate with packet metadata. The sizing of the ring_buffer has
-    # a direct effect on goprobe's base memory consumption
     ring_buffer:
-      # num_blocks describes the amount of blocks that the ring buffer
-      # has available and which the kernel can fill. Make sure to have
-      # more than 2 blocks per ring buffer
-      #
-      #  - 1 may be held in user land during writeout
-      #  - 1 may be written to by the kernel
-      #  - >=1 should be available in case there are many packets captured
       num_blocks: 4
-      # block_size of 1 MB should be enough for interfaces with much traffic
       block_size: 1048576
-  tun0:
-    # there is no need for capturing in promsicuous mode on tunnel interfaces
-    promisc: false
-    ring_buffer:
-      num_blocks: 4
-      # the traffic on a tunnel interface is always smaller than the traffic
-      # on, e.g. external interfaces. A smaller buffer should be sufficient
-      block_size: 524288
-# api configures goProbe's API server for control and querying
 api:
-  # addr defines what the API server binds to. This may also be a unix
-  # socket.
   addr: 0.0.0.0:8145
-  # profiling is enabled by default. It will only be run if one of the
-  # /debug/pprof endpoints is accessed and otherwise will not have an impact
-  # on performance.
-  # Leaving this enabled paves the way for continuous profiling and feeding
-  # such profiles back via PGO
-  profiling: true
-  # metrics enables scraping of metrics via /metrics endpoint
+    profiling: true
   metrics: true
-# logging sets the logging parameters for goprobe
 logging:
-  # level info is set not to spam the logs with writeout information for interfaces
   level: debug
-  # encoding logfmt is chosen over json for readability reasons
   encoding: logfmt
-  # destination describes the file goprobe logs to. If left empty, goprobe will log
-  # to stdout by default
-  destination: stdout

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -195,7 +195,7 @@ func (c *Capture) rotate(ctx context.Context) (agg *hashmap.AggFlowMap) {
 			// write volume metrics to prometheus
 			promNumFlows.WithLabelValues(c.iface).Set(float64(nFlows))
 
-			if nFlows > 0 && totals != nil {
+			if totals != nil {
 				promBytes.WithLabelValues(c.iface, "inbound").Add(float64(totals.BytesRcvd))
 				promBytes.WithLabelValues(c.iface, "outbound").Add(float64(totals.BytesSent))
 				promPackets.WithLabelValues(c.iface, "inbound").Add(float64(totals.PacketsRcvd))

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -185,11 +185,19 @@ func (c *Capture) rotate(ctx context.Context) (agg *hashmap.AggFlowMap) {
 
 	logger := logging.FromContext(ctx)
 
+	// write how many flows are currently in the map
+	numFlows.WithLabelValues(c.iface).Set(float64(c.flowLog.Len()))
+
 	if c.flowLog.Len() == 0 {
 		logger.Debug("there are currently no flow records available")
 		return
 	}
 	agg = c.flowLog.Rotate()
+
+	// write volume metrics to prometheus. This needs to happen after aggregation
+	// to make sure that the totals are correct
+	bytesReceived.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesReceived))
+	bytesSent.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesSent))
 
 	return
 }
@@ -360,9 +368,9 @@ func (c *Capture) status() (*capturetypes.CaptureStats, error) {
 	// main packet processing loop. If this counter moves slowly (as in gets
 	// gets an update only every 5 minutes) it's not an issue to understand
 	// processed data volumes across longer time frames
-	packetsProcessed.Add(float64(c.stats.Processed))
-	packetsDropped.Add(float64(stats.PacketsDropped))
-	captureErrors.Add(float64(c.stats.ParsingErrors.Sum()))
+	packetsProcessed.WithLabelValues(c.iface).Add(float64(c.stats.Processed))
+	packetsDropped.WithLabelValues(c.iface).Add(float64(stats.PacketsDropped))
+	captureErrors.WithLabelValues(c.iface).Add(float64(c.stats.ParsingErrors.Sum()))
 
 	res := capturetypes.CaptureStats{
 		StartedAt:      c.startedAt,

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -196,7 +196,7 @@ func (c *Capture) rotate(ctx context.Context) (agg *hashmap.AggFlowMap) {
 
 	// write volume metrics to prometheus. This needs to happen after aggregation
 	// to make sure that the totals are correct
-	bytesReceived.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesReceived))
+	bytesReceived.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesRcvd))
 	bytesSent.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesSent))
 
 	return

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -379,9 +379,11 @@ func (c *Capture) status() (*capturetypes.CaptureStats, error) {
 	// main packet processing loop. If this counter moves slowly (as in gets
 	// gets an update only every 5 minutes) it's not an issue to understand
 	// processed data volumes across longer time frames
-	promPacketsProcessed.WithLabelValues(c.iface).Add(float64(c.stats.Processed))
-	promPacketsDropped.WithLabelValues(c.iface).Add(float64(stats.PacketsDropped))
-	promCaptureErrors.WithLabelValues(c.iface).Add(float64(c.stats.ParsingErrors.Sum()))
+	go func(iface string, processed, dropped, errors uint64) {
+		promPacketsProcessed.WithLabelValues(iface).Add(float64(processed))
+		promPacketsDropped.WithLabelValues(iface).Add(float64(dropped))
+		promCaptureErrors.WithLabelValues(iface).Add(float64(errors))
+	}(c.iface, c.stats.Processed, stats.PacketsDropped, uint64(c.stats.ParsingErrors.Sum()))
 
 	res := capturetypes.CaptureStats{
 		StartedAt:      c.startedAt,

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -191,17 +191,17 @@ func (c *Capture) rotate(ctx context.Context) (agg *hashmap.AggFlowMap) {
 
 	var totals = &types.Counters{}
 	defer func() {
-		go func() {
+		go func(iface string) {
 			// write volume metrics to prometheus
 			promNumFlows.WithLabelValues(c.iface).Set(float64(nFlows))
 
 			if totals != nil {
-				promBytes.WithLabelValues(c.iface, "inbound").Add(float64(totals.BytesRcvd))
-				promBytes.WithLabelValues(c.iface, "outbound").Add(float64(totals.BytesSent))
-				promPackets.WithLabelValues(c.iface, "inbound").Add(float64(totals.PacketsRcvd))
-				promPackets.WithLabelValues(c.iface, "outbound").Add(float64(totals.PacketsSent))
+				promBytes.WithLabelValues(iface, "inbound").Add(float64(totals.BytesRcvd))
+				promBytes.WithLabelValues(iface, "outbound").Add(float64(totals.BytesSent))
+				promPackets.WithLabelValues(iface, "inbound").Add(float64(totals.PacketsRcvd))
+				promPackets.WithLabelValues(iface, "outbound").Add(float64(totals.PacketsSent))
 			}
-		}()
+		}(c.iface)
 	}()
 
 	if nFlows == 0 {

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -186,9 +186,9 @@ func (c *Capture) rotate(ctx context.Context) (agg *hashmap.AggFlowMap) {
 	logger := logging.FromContext(ctx)
 
 	// write how many flows are currently in the map
-	numFlows.WithLabelValues(c.iface).Set(float64(c.flowLog.Len()))
-
-	if c.flowLog.Len() == 0 {
+	nFlows := c.flowLog.Len()
+	promNumFlows.WithLabelValues(c.iface).Set(float64(nFlows))
+	if nFlows == 0 {
 		logger.Debug("there are currently no flow records available")
 		return
 	}
@@ -196,8 +196,8 @@ func (c *Capture) rotate(ctx context.Context) (agg *hashmap.AggFlowMap) {
 
 	// write volume metrics to prometheus. This needs to happen after aggregation
 	// to make sure that the totals are correct
-	bytesReceived.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesRcvd))
-	bytesSent.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesSent))
+	promtBytesReceived.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesRcvd))
+	promtBytesSent.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesSent))
 
 	return
 }
@@ -368,9 +368,9 @@ func (c *Capture) status() (*capturetypes.CaptureStats, error) {
 	// main packet processing loop. If this counter moves slowly (as in gets
 	// gets an update only every 5 minutes) it's not an issue to understand
 	// processed data volumes across longer time frames
-	packetsProcessed.WithLabelValues(c.iface).Add(float64(c.stats.Processed))
-	packetsDropped.WithLabelValues(c.iface).Add(float64(stats.PacketsDropped))
-	captureErrors.WithLabelValues(c.iface).Add(float64(c.stats.ParsingErrors.Sum()))
+	promPacketsProcessed.WithLabelValues(c.iface).Add(float64(c.stats.Processed))
+	promPacketsDropped.WithLabelValues(c.iface).Add(float64(stats.PacketsDropped))
+	promCaptureErrors.WithLabelValues(c.iface).Add(float64(c.stats.ParsingErrors.Sum()))
 
 	res := capturetypes.CaptureStats{
 		StartedAt:      c.startedAt,

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -196,8 +196,8 @@ func (c *Capture) rotate(ctx context.Context) (agg *hashmap.AggFlowMap) {
 
 	// write volume metrics to prometheus. This needs to happen after aggregation
 	// to make sure that the totals are correct
-	promtBytesReceived.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesRcvd))
-	promtBytesSent.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesSent))
+	promBytesReceived.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesRcvd))
+	promBytesSent.WithLabelValues(c.iface).Add(float64(c.flowLog.totals.BytesSent))
 
 	return
 }

--- a/pkg/capture/capture_manager.go
+++ b/pkg/capture/capture_manager.go
@@ -490,8 +490,8 @@ func (cm *Manager) rotate(ctx context.Context, writeoutChan chan<- capturetypes.
 
 	// observe rotation duration
 	t1 := time.Since(t0)
-	rotationDuration.Observe(float64(t1) / float64(time.Second))
-	interfacesCapturing.Set(float64(len(ifaces)))
+	promRotationDuration.Observe(float64(t1) / float64(time.Second))
+	promInterfacesCapturing.Set(float64(len(ifaces)))
 
 	logger.With(
 		"elapsed", t1.Round(time.Microsecond).String(),

--- a/pkg/capture/capture_test.go
+++ b/pkg/capture/capture_test.go
@@ -245,12 +245,12 @@ func BenchmarkRotation(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 
 			// Run best-case scenario (keep all flows)
-			aggMap := benchData[i].transferAndAggregate()
+			aggMap, _ := benchData[i].transferAndAggregate()
 			require.EqualValues(b, nFlows, len(benchData[i].flowMap))
 			require.EqualValues(b, nFlows, aggMap.Len())
 
 			// Run worst-case scenario (keep no flows)
-			aggMap = benchData[i].transferAndAggregate()
+			aggMap, _ = benchData[i].transferAndAggregate()
 			require.EqualValues(b, 0, len(benchData[i].flowMap))
 			require.EqualValues(b, 0, aggMap.Len())
 		}

--- a/pkg/capture/flow.go
+++ b/pkg/capture/flow.go
@@ -98,8 +98,7 @@ func ParsePacket(ipLayer capture.IPLayer) (epHash capturetypes.EPHash, isIPv4 bo
 		copy(epHash[0:4], ipLayer[12:16])
 		copy(epHash[16:20], ipLayer[16:20])
 
-		switch protocol {
-		case capturetypes.TCP, capturetypes.UDP:
+		if protocol == capturetypes.TCP || protocol == capturetypes.UDP {
 
 			dport := ipLayer[ipv4.HeaderLen+2 : ipv4.HeaderLen+4]
 			sport := ipLayer[ipv4.HeaderLen : ipv4.HeaderLen+2]
@@ -122,7 +121,7 @@ func ParsePacket(ipLayer capture.IPLayer) (epHash capturetypes.EPHash, isIPv4 bo
 				}
 				auxInfo = ipLayer[ipv4.HeaderLen+13] // store TCP flags
 			}
-		case capturetypes.ICMP:
+		} else if protocol == capturetypes.ICMP {
 			auxInfo = ipLayer[ipv4.HeaderLen] // store ICMP type
 		}
 	} else if ipLayerType == ipLayerTypeV6 {
@@ -135,8 +134,7 @@ func ParsePacket(ipLayer capture.IPLayer) (epHash capturetypes.EPHash, isIPv4 bo
 		copy(epHash[0:16], ipLayer[8:24])
 		copy(epHash[16:32], ipLayer[24:40])
 
-		switch protocol {
-		case capturetypes.TCP, capturetypes.UDP:
+		if protocol == capturetypes.TCP || protocol == capturetypes.UDP {
 
 			dport := ipLayer[ipv6.HeaderLen+2 : ipv6.HeaderLen+4]
 			sport := ipLayer[ipv6.HeaderLen : ipv6.HeaderLen+2]
@@ -159,7 +157,7 @@ func ParsePacket(ipLayer capture.IPLayer) (epHash capturetypes.EPHash, isIPv4 bo
 				}
 				auxInfo = ipLayer[ipv6.HeaderLen+13] // store TCP flags
 			}
-		case capturetypes.ICMPv6:
+		} else if protocol == capturetypes.ICMPv6 {
 			auxInfo = ipLayer[ipv6.HeaderLen] // store ICMP type
 		}
 	} else {

--- a/pkg/capture/flow.go
+++ b/pkg/capture/flow.go
@@ -102,7 +102,8 @@ func ParsePacket(ipLayer capture.IPLayer) (epHash capturetypes.EPHash, isIPv4 bo
 		copy(epHash[0:4], ipLayer[12:16])
 		copy(epHash[16:20], ipLayer[16:20])
 
-		if protocol == capturetypes.TCP || protocol == capturetypes.UDP {
+		switch protocol {
+		case capturetypes.TCP, capturetypes.UDP:
 
 			dport := ipLayer[ipv4.HeaderLen+2 : ipv4.HeaderLen+4]
 			sport := ipLayer[ipv4.HeaderLen : ipv4.HeaderLen+2]
@@ -125,10 +126,9 @@ func ParsePacket(ipLayer capture.IPLayer) (epHash capturetypes.EPHash, isIPv4 bo
 				}
 				auxInfo = ipLayer[ipv4.HeaderLen+13] // store TCP flags
 			}
-		} else if protocol == capturetypes.ICMP {
+		case capturetypes.ICMP:
 			auxInfo = ipLayer[ipv4.HeaderLen] // store ICMP type
 		}
-
 	} else if ipLayerType == ipLayerTypeV6 {
 
 		_ = ipLayer[ipv6.HeaderLen] // bounds check hint to compiler
@@ -139,7 +139,8 @@ func ParsePacket(ipLayer capture.IPLayer) (epHash capturetypes.EPHash, isIPv4 bo
 		copy(epHash[0:16], ipLayer[8:24])
 		copy(epHash[16:32], ipLayer[24:40])
 
-		if protocol == capturetypes.TCP || protocol == capturetypes.UDP {
+		switch protocol {
+		case capturetypes.TCP, capturetypes.UDP:
 
 			dport := ipLayer[ipv6.HeaderLen+2 : ipv6.HeaderLen+4]
 			sport := ipLayer[ipv6.HeaderLen : ipv6.HeaderLen+2]
@@ -162,10 +163,9 @@ func ParsePacket(ipLayer capture.IPLayer) (epHash capturetypes.EPHash, isIPv4 bo
 				}
 				auxInfo = ipLayer[ipv6.HeaderLen+13] // store TCP flags
 			}
-		} else if protocol == capturetypes.ICMPv6 {
+		case capturetypes.ICMPv6:
 			auxInfo = ipLayer[ipv6.HeaderLen] // store ICMP type
 		}
-
 	} else {
 		errno = capturetypes.ErrnoInvalidIPHeader
 		return

--- a/pkg/capture/flow.go
+++ b/pkg/capture/flow.go
@@ -227,6 +227,11 @@ func (f *FlowLog) Aggregate() (agg *hashmap.AggFlowMap) {
 	// Reusable key conversion buffers
 	keyBufV4, keyBufV6 := types.NewEmptyV4Key(), types.NewEmptyV6Key()
 	for _, v := range f.flowMap {
+		// update totals
+		f.totals.BytesRcvd += v.bytesRcvd
+		f.totals.BytesSent += v.bytesSent
+		f.totals.PacketsRcvd += v.packetsRcvd
+		f.totals.PacketsSent += v.packetsSent
 
 		// Check if the flow actually has any interesting information for us
 		if v.packetsRcvd != 0 || v.packetsSent != 0 {
@@ -239,12 +244,6 @@ func (f *FlowLog) Aggregate() (agg *hashmap.AggFlowMap) {
 				keyBufV6.PutAllV6(v.epHash[0:16], v.epHash[16:32], v.epHash[32:34], v.epHash[36])
 				agg.SetOrUpdate(keyBufV6, v.isIPv4, v.bytesRcvd, v.bytesSent, v.packetsRcvd, v.packetsSent)
 			}
-
-			// update totals
-			f.totals.BytesRcvd += v.bytesRcvd
-			f.totals.BytesSent += v.bytesSent
-			f.totals.PacketsRcvd += v.packetsRcvd
-			f.totals.PacketsSent += v.packetsSent
 		}
 	}
 
@@ -263,6 +262,11 @@ func (f *FlowLog) transferAndAggregate() (agg *hashmap.AggFlowMap) {
 	keyBufV4, keyBufV6 := types.NewEmptyV4Key(), types.NewEmptyV6Key()
 
 	for k, v := range f.flowMap {
+		// update totals
+		f.totals.BytesRcvd += v.bytesRcvd
+		f.totals.BytesSent += v.bytesSent
+		f.totals.PacketsRcvd += v.packetsRcvd
+		f.totals.PacketsSent += v.packetsSent
 
 		// Check if the flow actually has any interesting information for us, otherwise
 		// delete it from the FlowMap
@@ -289,12 +293,6 @@ func (f *FlowLog) transferAndAggregate() (agg *hashmap.AggFlowMap) {
 		} else {
 			delete(f.flowMap, k)
 		}
-
-		// update totals
-		f.totals.BytesRcvd += v.bytesRcvd
-		f.totals.BytesSent += v.bytesSent
-		f.totals.PacketsRcvd += v.packetsRcvd
-		f.totals.PacketsSent += v.packetsSent
 	}
 
 	return

--- a/pkg/capture/flow.go
+++ b/pkg/capture/flow.go
@@ -248,15 +248,15 @@ func (f *FlowLog) transferAndAggregate() (agg *hashmap.AggFlowMap, totals *types
 	keyBufV4, keyBufV6 := types.NewEmptyV4Key(), types.NewEmptyV6Key()
 
 	for k, v := range f.flowMap {
-		// update totals
-		totals.BytesRcvd += v.bytesRcvd
-		totals.BytesSent += v.bytesSent
-		totals.PacketsRcvd += v.packetsRcvd
-		totals.PacketsSent += v.packetsSent
 
 		// Check if the flow actually has any interesting information for us, otherwise
 		// delete it from the FlowMap
 		if v.packetsRcvd > 0 || v.packetsSent > 0 {
+			// update totals
+			totals.BytesRcvd += v.bytesRcvd
+			totals.BytesSent += v.bytesSent
+			totals.PacketsRcvd += v.packetsRcvd
+			totals.PacketsSent += v.packetsSent
 
 			// Populate key buffer according to source flow and update result
 			if v.isIPv4 {

--- a/pkg/capture/metrics.go
+++ b/pkg/capture/metrics.go
@@ -18,21 +18,21 @@ var promPacketsProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
 },
 	[]string{"iface"},
 )
-var promBytesReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
+var promBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
-	Name:      "bytes_received_total",
-	Help:      "Number of bytes received",
+	Name:      "bytes_total",
+	Help:      "Number of bytes tracked in flow map",
 },
-	[]string{"iface"},
+	[]string{"iface", "direction"},
 )
-var promBytesSent = prometheus.NewCounterVec(prometheus.CounterOpts{
+var promPackets = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
-	Name:      "bytes_sent_total",
-	Help:      "Number of bytes sent",
+	Name:      "packets_total",
+	Help:      "Number of packets seen in flow map",
 },
-	[]string{"iface"},
+	[]string{"iface", "direction"},
 )
 var promNumFlows = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: config.ServiceName,
@@ -80,8 +80,8 @@ func init() {
 	prometheus.MustRegister(
 		promPacketsProcessed,
 		promPacketsDropped,
-		promBytesReceived,
-		promBytesSent,
+		promBytes,
+		promPackets,
 		promNumFlows,
 		promCaptureErrors,
 		promInterfacesCapturing,

--- a/pkg/capture/metrics.go
+++ b/pkg/capture/metrics.go
@@ -10,24 +10,54 @@ const (
 	captureManagerSubsystem = "capture_manager"
 )
 
-var packetsProcessed = prometheus.NewCounter(prometheus.CounterOpts{
+var packetsProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
 	Name:      "packets_processed_total",
-	Help:      "Number of packets processed, aggregated over all interfaces",
-})
-var packetsDropped = prometheus.NewCounter(prometheus.CounterOpts{
+	Help:      "Number of packets processed",
+},
+	[]string{"iface"},
+)
+var bytesReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: config.ServiceName,
+	Subsystem: captureSubsystem,
+	Name:      "bytes_received_total",
+	Help:      "Number of bytes received",
+},
+	[]string{"iface"},
+)
+var bytesSent = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: config.ServiceName,
+	Subsystem: captureSubsystem,
+	Name:      "bytes_received_total",
+	Help:      "Number of bytes send",
+},
+	[]string{"iface"},
+)
+var numFlows = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: config.ServiceName,
+	Subsystem: captureSubsystem,
+	Name:      "flows_total",
+	Help:      "Number of flows present in the flow map",
+},
+	[]string{"iface"},
+)
+var packetsDropped = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
 	Name:      "packets_dropped_total",
-	Help:      "Number of packets dropped, aggregated over all interfaces",
-})
-var captureErrors = prometheus.NewCounter(prometheus.CounterOpts{
+	Help:      "Number of packets dropped",
+},
+	[]string{"iface"},
+)
+var captureErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
 	Name:      "errors_total",
-	Help:      "Number of errors encountered during packet capture, aggregated over all interfaces",
-})
+	Help:      "Number of errors encountered during packet capture",
+},
+	[]string{"iface"},
+)
 
 var interfacesCapturing = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: config.ServiceName,
@@ -49,6 +79,8 @@ func init() {
 	prometheus.MustRegister(
 		packetsProcessed,
 		packetsDropped,
+		bytesReceived,
+		bytesSent,
 		captureErrors,
 		interfacesCapturing,
 		rotationDuration,

--- a/pkg/capture/metrics.go
+++ b/pkg/capture/metrics.go
@@ -10,7 +10,7 @@ const (
 	captureManagerSubsystem = "capture_manager"
 )
 
-var packetsProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
+var promPacketsProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
 	Name:      "packets_processed_total",
@@ -18,7 +18,7 @@ var packetsProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
 },
 	[]string{"iface"},
 )
-var bytesReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
+var promBytesReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
 	Name:      "bytes_received_total",
@@ -26,15 +26,15 @@ var bytesReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
 },
 	[]string{"iface"},
 )
-var bytesSent = prometheus.NewCounterVec(prometheus.CounterOpts{
+var promBytesSent = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
-	Name:      "bytes_received_total",
-	Help:      "Number of bytes send",
+	Name:      "bytes_sent_total",
+	Help:      "Number of bytes sent",
 },
 	[]string{"iface"},
 )
-var numFlows = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+var promNumFlows = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
 	Name:      "flows_total",
@@ -42,7 +42,7 @@ var numFlows = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 },
 	[]string{"iface"},
 )
-var packetsDropped = prometheus.NewCounterVec(prometheus.CounterOpts{
+var promPacketsDropped = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
 	Name:      "packets_dropped_total",
@@ -50,7 +50,7 @@ var packetsDropped = prometheus.NewCounterVec(prometheus.CounterOpts{
 },
 	[]string{"iface"},
 )
-var captureErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+var promCaptureErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
 	Name:      "errors_total",
@@ -59,14 +59,15 @@ var captureErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 	[]string{"iface"},
 )
 
-var interfacesCapturing = prometheus.NewGauge(prometheus.GaugeOpts{
+var promInterfacesCapturing = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureManagerSubsystem,
 	Name:      "interfaces_capturing_total",
 	Help:      "Number of interfaces that are actively capturing traffic",
 })
 
-var rotationDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+// not exposing the interface due to the high-cardinality nature of the histogram
+var promRotationDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureManagerSubsystem,
 	Name:      "rotation_duration_seconds",
@@ -77,13 +78,13 @@ var rotationDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 
 func init() {
 	prometheus.MustRegister(
-		packetsProcessed,
-		packetsDropped,
-		bytesReceived,
-		bytesSent,
-		numFlows,
-		captureErrors,
-		interfacesCapturing,
-		rotationDuration,
+		promPacketsProcessed,
+		promPacketsDropped,
+		promBytesReceived,
+		promBytesSent,
+		promNumFlows,
+		promCaptureErrors,
+		promInterfacesCapturing,
+		promRotationDuration,
 	)
 }

--- a/pkg/capture/metrics.go
+++ b/pkg/capture/metrics.go
@@ -38,7 +38,7 @@ var numFlows = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: config.ServiceName,
 	Subsystem: captureSubsystem,
 	Name:      "flows_total",
-	Help:      "Number of flows present in the flow map",
+	Help:      "Number of flows tracked in the flow map",
 },
 	[]string{"iface"},
 )
@@ -81,6 +81,7 @@ func init() {
 		packetsDropped,
 		bytesReceived,
 		bytesSent,
+		numFlows,
 		captureErrors,
 		interfacesCapturing,
 		rotationDuration,

--- a/pkg/types/keyval.go
+++ b/pkg/types/keyval.go
@@ -474,11 +474,3 @@ func (c Counters) IsBidirectional() bool {
 func (c Counters) IsUnidirectional() bool {
 	return c.IsOnlyInbound() || c.IsOnlyOutbound()
 }
-
-// Reset resets all counters to zero
-func (c Counters) Reset() {
-	c.BytesRcvd = 0
-	c.BytesSent = 0
-	c.PacketsRcvd = 0
-	c.PacketsSent = 0
-}

--- a/pkg/types/keyval.go
+++ b/pkg/types/keyval.go
@@ -474,3 +474,11 @@ func (c Counters) IsBidirectional() bool {
 func (c Counters) IsUnidirectional() bool {
 	return c.IsOnlyInbound() || c.IsOnlyOutbound()
 }
+
+// Reset resets all counters to zero
+func (c Counters) Reset() {
+	c.BytesRcvd = 0
+	c.BytesSent = 0
+	c.PacketsRcvd = 0
+	c.PacketsSent = 0
+}


### PR DESCRIPTION
### Background

This commits add three new metrics to goProbe:

* `goprobe_capture_bytes_total`
* `goprobe_capture_packets_total`
* `goprobe_capture_flows_total`

These are calculated and supplied to prometheus only upon aggregation, which is in line with the approach chosen for the other capture metrics during `status()` calls. The `bytes` and `packets` metrics also have a label `direction=(inbount|outbound)`.

### Major Changes

Let's unleash cardinality onto the metrics backends. Metrics of the `capture` subsystem are now vectors with exactly one label: `iface`.

The decision was made to discern better

* on which interface errors/drops occured
* how large the flow maps were
* how much traffic volume was observed per interface

The latter two providing a more detailed understanding of bursts or interfaces over which many sessions are routed.

Closes #236 