### PR TITLE
[feature] API: Add info endpoints for deployment in k8s

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,12 @@
+package api
+
+const (
+	infoPrefix = "/-"
+
+	// HealthRoute denotes the route / URI path to the health endpoint
+	HealthRoute = infoPrefix + "/health"
+	// InfoRoute denotes the route / URI path to the info endpoint
+	InfoRoute = infoPrefix + "/info"
+	// ReadyRoute denotes the route / URI path to the ready endpoint
+	ReadyRoute = infoPrefix + "/ready"
+)

--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -124,6 +124,13 @@ func NewDefault(addr string, opts ...Option) *DefaultClient {
 		c.scheme = c.scheme + unixIdent
 	}
 
+	// extract the scheme from the address if it is available
+	scheme, addr := api.ExtractSchemeAddr(c.hostAddr)
+	if scheme != "" {
+		c.scheme = scheme
+		c.hostAddr = addr
+	}
+
 	c.client = &http.Client{
 		// trace propagation is enabled by default
 		Transport: &transport{

--- a/pkg/api/globalquery/server/query.go
+++ b/pkg/api/globalquery/server/query.go
@@ -22,6 +22,7 @@ func RegisterQueryHandler(engine *gin.Engine, route string, resolver hosts.Resol
 		)
 	}
 
-	engine.GET(route, handler)  // support for URL-encoded form data GET requests
-	engine.POST(route, handler) // support for JSON or form-data body POST requests
+	queryGroup := engine.Group(route)
+	queryGroup.GET("/", handler)  // support for URL-encoded form data GET requests
+	queryGroup.POST("/", handler) // support for JSON or form-data body POST requests
 }

--- a/pkg/api/globalquery/spec/openapi.yaml
+++ b/pkg/api/globalquery/spec/openapi.yaml
@@ -11,6 +11,12 @@ servers:
 paths:
   /_query:
     $ref: '../../spec/paths/query.yaml'
+  /-/health:
+    $ref: '../../spec/paths/health.yaml'
+  /-/info:
+    $ref: '../../spec/paths/info.yaml'
+  /-/ready:
+    $ref: '../../spec/paths/ready.yaml'
 components:
   schemas:
     $ref: '../../spec/schemas/_index.yaml'

--- a/pkg/api/globalquery/spec/schemas/_index.yaml
+++ b/pkg/api/globalquery/spec/schemas/_index.yaml
@@ -27,3 +27,7 @@ Labels:
   $ref: '../../../spec/schemas/Labels.yaml'
 Attributes:
   $ref: '../../../spec/schemas/Attributes.yaml'
+
+# info endpoints
+ServiceInfo:
+  $ref: '../../../spec/schemas/ServiceInfo.yaml'

--- a/pkg/api/info.go
+++ b/pkg/api/info.go
@@ -11,10 +11,10 @@ import (
 // ServiceInfo summarizes the running service's name, version, and commit. If running in
 // kubernetes, it will also print the name of the pod which returned the API call
 type ServiceInfo struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-	Commit  string `json:"commit,omitempty"`
-	Pod     string `json:"pod,omitempty"`
+	Name    string `json:"name"`             // Name: service name. Example: global-query
+	Version string `json:"version"`          // Version: (semantic) version and commit short.  Example: 4.0.0-824f5847
+	Commit  string `json:"commit,omitempty"` // Commit: full git commit SHA. Example: 824f58479a8f326cb350085b3a0e287645e11bc1
+	Pod     string `json:"pod,omitempty"`    // Pod: name of kubernetes pod, if available. Example: global-query-5987cbf795-dvnsl
 }
 
 // ServiceInfoHandler returns a handler that returns the service name, version, and commit

--- a/pkg/api/info.go
+++ b/pkg/api/info.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/els0r/goProbe/pkg/version"
+	"github.com/gin-gonic/gin"
+)
+
+// ServiceInfo summarizes the running service's name, version, and commit. If running in
+// kubernetes, it will also print the name of the pod which returned the API call
+type ServiceInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Commit  string `json:"commit,omitempty"`
+	Pod     string `json:"pod,omitempty"`
+}
+
+// ServiceInfoHandler returns a handler that returns the service name, version, and commit
+func ServiceInfoHandler(serviceName string) gin.HandlerFunc {
+	info := &ServiceInfo{
+		Name:    serviceName,
+		Version: version.Short(),
+		Commit:  version.GitSHA,
+	}
+
+	// try to ascertain the running pod's name
+	for _, env := range []string{"POD_NAME", "POD", "PODNAME"} {
+		podName := os.Getenv(env)
+		if podName != "" {
+			info.Pod = podName
+			break
+		}
+	}
+
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, info)
+	}
+}
+
+// HealthHandler returns a handler that returns a 200 OK response if the server is healthy
+func HealthHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, "healthy")
+	}
+}
+
+// ReadyHandler returns a handler that returns a 200 OK response if the server is ready
+func ReadyHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, "ready")
+	}
+}

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -131,10 +131,9 @@ func (server *DefaultServer) QueryRateLimiter() (*rate.Limiter, bool) {
 
 func (server *DefaultServer) registerInfoRoutes() {
 	// make sure these endpoints don't interfere with the standard API path
-	infoGroup := server.router.Group("/-")
-	infoGroup.GET("/info", api.ServiceInfoHandler(server.serviceName))
-	infoGroup.GET("/health", api.HealthHandler())
-	infoGroup.GET("/ready", api.ReadyHandler())
+	server.router.GET(api.InfoRoute, api.ServiceInfoHandler(server.serviceName))
+	server.router.GET(api.HealthRoute, api.HealthHandler())
+	server.router.GET(api.ReadyRoute, api.ReadyHandler())
 }
 
 func (server *DefaultServer) registerMiddlewares() {

--- a/pkg/api/spec/openapi.yaml
+++ b/pkg/api/spec/openapi.yaml
@@ -7,6 +7,13 @@ servers:
 paths:
   /_query:
     $ref: './paths/query.yaml'
+  /-/health:
+    $ref: './paths/health.yaml'
+  /-/info:
+    $ref: './paths/info.yaml'
+  /-/ready:
+    $ref: './paths/ready.yaml'
 components:
   schemas:
     $ref: './schemas/_index.yaml'
+

--- a/pkg/api/spec/paths/health.yaml
+++ b/pkg/api/spec/paths/health.yaml
@@ -1,0 +1,14 @@
+get:
+  summary: Get health response
+  tags:
+    - runtime info
+  responses:
+    '200':
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: string
+            description: Healthy string
+            example: healthy
+

--- a/pkg/api/spec/paths/info.yaml
+++ b/pkg/api/spec/paths/info.yaml
@@ -1,0 +1,11 @@
+get:
+  summary: Get service information
+  tags:
+    - runtime info
+  responses:
+    '200':
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ServiceInfo.yaml'

--- a/pkg/api/spec/paths/ready.yaml
+++ b/pkg/api/spec/paths/ready.yaml
@@ -1,0 +1,14 @@
+get:
+  summary: Get ready response
+  tags:
+    - runtime info
+  responses:
+    '200':
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            type: string
+            description: Ready string
+            example: ready
+

--- a/pkg/api/spec/schemas/Row.yaml
+++ b/pkg/api/spec/schemas/Row.yaml
@@ -1,12 +1,12 @@
-  type: object
-  description: Row is a human-readable, aggregatable representation of goDB's data
-  required:
-    - attributes
-    - counters
-  properties:
-    labels:
-      $ref: './Labels.yaml'
-    attributes:
-      $ref: './Attributes.yaml'
-    counters:
-      $ref: './Counters.yaml'
+type: object
+description: Row is a human-readable, aggregatable representation of goDB's data
+required:
+  - attributes
+  - counters
+properties:
+  labels:
+    $ref: './Labels.yaml'
+  attributes:
+    $ref: './Attributes.yaml'
+  counters:
+    $ref: './Counters.yaml'

--- a/pkg/api/spec/schemas/ServiceInfo.yaml
+++ b/pkg/api/spec/schemas/ServiceInfo.yaml
@@ -1,0 +1,22 @@
+type: object
+description: ServiceInfo includes properties for the service name, version, commit, and the name of the Kubernetes pod, if available.
+required:
+  - name
+  - version
+properties:
+  name:
+    type: string
+    description: Service name
+    example: global-query
+  version:
+    type: string
+    description: Semantic version and commit short
+    example: 4.0.0-824f5847
+  commit:
+    type: string
+    description: Full git commit SHA.
+    example: 824f58479a8f326cb350085b3a0e287645e11bc1
+  pod:
+    type: string
+    description: Name of the Kubernetes pod, if available
+    example: global-query-5987cbf795-dvnsl

--- a/pkg/api/spec/schemas/_index.yaml
+++ b/pkg/api/spec/schemas/_index.yaml
@@ -27,3 +27,7 @@ Labels:
   $ref: './Labels.yaml'
 Attributes:
   $ref: './Attributes.yaml'
+
+# info endpoints
+ServiceInfo:
+  $ref: './ServiceInfo.yaml'

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -6,7 +6,9 @@ import (
 )
 
 const (
-	unixPrefix = "unix:"
+	unixPrefix  = "unix:"
+	httpPrefix  = "http://"
+	httpsPrefix = "https://"
 )
 
 // ExtractUnixSocket determines whether the provided address contains a unix:
@@ -16,4 +18,19 @@ func ExtractUnixSocket(addr string) (socketFile string) {
 		socketFile = filepath.Clean(strings.TrimPrefix(addr, unixPrefix))
 	}
 	return
+}
+
+// ExtractSchemeAddr extracts the scheme from the address if it is present and returns
+// the trimmed address with it. If not scheme match is found, scheme is empty and the
+// input to the function will be returned in address
+func ExtractSchemeAddr(addr string) (scheme string, address string) {
+	switch {
+	case strings.HasPrefix(addr, unixPrefix):
+		return "", filepath.Clean(strings.TrimPrefix(addr, unixPrefix))
+	case strings.HasPrefix(addr, httpPrefix):
+		return httpPrefix, filepath.Clean(strings.TrimPrefix(addr, httpPrefix))
+	case strings.HasPrefix(addr, httpsPrefix):
+		return httpsPrefix, filepath.Clean(strings.TrimPrefix(addr, httpsPrefix))
+	}
+	return "", addr
 }

--- a/pkg/capture/capture_test.go
+++ b/pkg/capture/capture_test.go
@@ -361,7 +361,7 @@ func testDeadlockHighTraffic(t *testing.T) {
 		select {
 		case err := <-errChan:
 			doneChan <- err
-		case <-time.After(30 * time.Second):
+		case <-time.After(time.Minute):
 			doneChan <- errors.New("potential deadlock situation on rotation logic (no termination confirmation received from mock source)")
 		}
 
@@ -370,7 +370,7 @@ func testDeadlockHighTraffic(t *testing.T) {
 
 	require.Nil(t, <-doneChan)
 
-	if time.Since(start) > 30*time.Second {
+	if time.Since(start) > 3*time.Minute {
 		t.Fatalf("potential deadlock situation on rotation logic (test took %v)", time.Since(start))
 	}
 }


### PR DESCRIPTION
Provides primitives under `/-/` to:

* show which version is running (and which pod if deployed in kubernetes)
* respond to health probes
* respond to readiness probes
