### PR TITLE
[feature] Support traffic direction filter autocompletion

### DIFF
--- a/cmd/goquery_completion/conditional.go
+++ b/cmd/goquery_completion/conditional.go
@@ -18,8 +18,7 @@ import (
 	"github.com/els0r/goProbe/pkg/types"
 )
 
-func openParens(tokens []string) int {
-	open := 0
+func openParens(tokens []string) (open int) {
 	for _, token := range tokens {
 		switch token {
 		case "(":
@@ -29,6 +28,82 @@ func openParens(tokens []string) int {
 		}
 	}
 	return open
+}
+
+// dirKeywordCount returns the number of dir keyword occurrences in tokens.
+func dirKeywordCount(tokens []string) (count int) {
+	for _, token := range tokens {
+		if token == types.FilterKeywordDirection || token == types.FilterKeywordDirectionSugared {
+			count++
+		}
+	}
+	return count
+}
+
+// firstUnnestedBinaryOp returns the position of the first 'unnested' binary logical
+// operator inside tokens and the respective token.
+// It returns -1 and an empty string if tokens do not contain any binary logical operator.
+func firstUnnestedBinaryOp(tokens []string) (int, string) {
+	for i, token := range tokens {
+		if (token == "&" || token == "|") && openParens(tokens[:i]) == 0 {
+			return i, token
+		}
+	}
+	return -1, ""
+}
+
+// unnestedBinaryOpCount returns the number of 'unnested' binary operators within tokens.
+func unnestedBinaryOpCount(tokens []string) (count int) {
+	for i, token := range tokens {
+		if (token == "&" || token == "|") && openParens(tokens[:i]) == 0 {
+			count++
+		}
+	}
+	return count
+}
+
+// conditionStringValid checks if the condition string is valid,
+// in which case suggestions have to be provided.
+// Returns true if the condition string is valid, and false otherwise.
+func conditionStringValid(tokens []string) bool {
+	dirKeywordCount := dirKeywordCount(tokens)
+	firstUnnestedBinaryOpPos, firstUnnestedBinaryOp := firstUnnestedBinaryOp(tokens)
+	unnestedBinaryOpCount := unnestedBinaryOpCount(tokens)
+
+	// If the dir keyword occurs more than once, the condition is invalid.
+	if dirKeywordCount > 1 {
+		return false
+	}
+
+	// If the dir keyword occurs exactly once but there's more than
+	// one 'unnested' binary operator, the condition is invalid.
+	if dirKeywordCount == 1 && unnestedBinaryOpCount > 1 {
+		return false
+	}
+
+	// Get position of dir keyword within the condition string.
+	var dirKeywordPos = -1
+	for i, token := range tokens {
+		if token == types.FilterKeywordDirection || token == types.FilterKeywordDirectionSugared {
+			dirKeywordPos = i
+			break
+		}
+	}
+
+	// If the dir keyword already occurs, and the first 'unnested' binary operator is
+	// not an &, the condition string is invalid.
+	if dirKeywordCount > 0 && firstUnnestedBinaryOpPos >= 0 && firstUnnestedBinaryOp != "&" {
+		return false
+	}
+
+	// If the dir keyword already occurs (but not directly in the beginning of the
+	// condition string) and doesn't directly follow the top-level &,
+	// the condition string is invalid.
+	if dirKeywordPos > 0 && dirKeywordPos != firstUnnestedBinaryOpPos+1 {
+		return false
+	}
+
+	return true
 }
 
 func nextAll(prevprev, prev string, openParens int) []suggestion {
@@ -55,6 +130,8 @@ func nextAll(prevprev, prev string, openParens int) []suggestion {
 			s(types.DportName, false),
 			s("port", false),
 			s(types.ProtoName, false),
+			s(types.FilterKeywordDirection, false),
+			s(types.FilterKeywordDirectionSugared, false),
 		}
 	case "!":
 		return []suggestion{
@@ -85,12 +162,22 @@ func nextAll(prevprev, prev string, openParens int) []suggestion {
 			s("<=", false),
 			s(">=", false),
 		}
+	case types.FilterKeywordDirection, types.FilterKeywordDirectionSugared:
+		return []suggestion{
+			s("=", false),
+		}
 	case "=", "!=", "<", ">", "<=", ">=":
 		switch prevprev {
 		case types.ProtoName:
 			var result []suggestion
 			for name := range protocols.IPProtocolIDs {
 				result = append(result, suggestion{name, name + " ...", openParens == 0})
+			}
+			return result
+		case types.FilterKeywordDirection, types.FilterKeywordDirectionSugared:
+			var result []suggestion
+			for _, direction := range types.DirectionFilters {
+				result = append(result, s(direction, true))
 			}
 			return result
 		default:
@@ -107,6 +194,13 @@ func nextAll(prevprev, prev string, openParens int) []suggestion {
 		return []suggestion{
 			s("&", false),
 			s("|", false),
+		}
+	case types.FilterTypeDirectionIn, types.FilterTypeDirectionOut,
+		types.FilterTypeDirectionUni, types.FilterTypeDirectionBi,
+		types.FilterTypeDirectionInSugared, types.FilterTypeDirectionOutSugared,
+		types.FilterTypeDirectionUniSugared, types.FilterTypeDirectionBiSugared:
+		return []suggestion{
+			s("&", false),
 		}
 	default:
 		switch prevprev {
@@ -152,11 +246,28 @@ func conditional(args []string) []string {
 
 	next := func(tokens []string) suggestions {
 		var suggs []suggestion
-		for _, sugg := range nextAll(antepenultimate(tokens), penultimate(tokens), openParens(tokens)) {
-			if strings.HasPrefix(sugg.token, last(tokens)) {
-				suggs = append(suggs, sugg)
+
+		// Only provide suggestions for currently valid condition strings.
+		if conditionStringValid(tokens) {
+			prevprev := antepenultimate(tokens)
+			prev := penultimate(tokens)
+			openParens := openParens(tokens)
+			last := last(tokens)
+			dirKeywordCount := dirKeywordCount(tokens[:len(tokens)-1])
+			for _, sugg := range nextAll(prevprev, prev, openParens) {
+				if strings.HasPrefix(sugg.token, last) {
+					// Check if suggestion is valid based on the current condition string.
+					if verifySuggestion(sugg, tokens, prev, openParens, dirKeywordCount) {
+						suggs = append(suggs, sugg)
+					}
+				}
+			}
+			// Check if termination of condition string must be enforced in order to be valid.
+			if conditionMustTerminate(suggs, prevprev, prev, last, openParens, dirKeywordCount, len(tokens)) {
+				return knownSuggestions{[]suggestion{{token: quit, accept: false}}}
 			}
 		}
+
 		if len(suggs) == 0 {
 			return unknownSuggestions{}
 		}
@@ -168,4 +279,128 @@ func conditional(args []string) []string {
 	}
 
 	return complete(tokenize, join, next, unknown, last(args))
+}
+
+// verifySuggestion enforces some structural constraints on the condition,
+// only if the current suggestion is the dir keyword, or the dir keyword
+// has already appeared, ensuring that the dir keyword only occurs at valid places.
+func verifySuggestion(sugg suggestion, tokens []string, prev string, openParens, dirKeywordCount int) bool {
+	if strings.Contains(sugg.token, types.FilterKeywordDirection) ||
+		strings.Contains(sugg.token, types.FilterKeywordDirectionSugared) ||
+		dirKeywordCount > 0 {
+		// Filter out invalid suggestions.
+		if !checkDirKeywordConstraints(sugg, tokens, prev, openParens, dirKeywordCount) {
+			return false
+		}
+	}
+	return true
+}
+
+// checkDirKeywordConstraints checks whether sugg is a valid suggestion with respect to the
+// constraints on the structure of the condition string introduced by the dir keyword.
+// Returns true if sugg is a valid suggestion and false otherwise.
+func checkDirKeywordConstraints(sugg suggestion, tokens []string, prev string, openParens, dirKeywordCount int) bool {
+	firstUnnestedBinaryOpPos, firstUnnestedBinaryOp := firstUnnestedBinaryOp(tokens)
+	nTokens := len(tokens)
+	// Determine whether prev is a top-level conjunction.
+	topLevelAnd := firstUnnestedBinaryOp == "&" && firstUnnestedBinaryOpPos == nTokens-2
+	// Determine whether a top-level conjunction has previously occurred.
+	topLevelAndOccurred := firstUnnestedBinaryOp == "&" && firstUnnestedBinaryOpPos <= nTokens-2
+
+	// The dir keyword must only be suggested at the start of the condition (condition string currently empty)
+	// or directly after a top-level conjunction.
+	if !strings.Contains(sugg.token, "directional") &&
+		(strings.Contains(sugg.token, types.FilterKeywordDirection) || strings.Contains(sugg.token, types.FilterKeywordDirectionSugared)) {
+		if !(prev == "" || (topLevelAnd && dirKeywordCount == 0)) {
+			return false
+		}
+	}
+
+	// An 'unnested' disjunction is disallowed if the dir keyword is already present.
+	if sugg.token == "|" && dirKeywordCount > 0 && openParens == 0 {
+		return false
+	}
+
+	// If dir keyword has already occurred and there is already a top-level conjunction,
+	// no other 'unnested' conjunction or disjunction is allowed
+	//(otherwise dir keyword would not be part of the top-level conjunct anymore).
+	if sugg.token == "&" && dirKeywordCount > 0 && topLevelAndOccurred && openParens == 0 {
+		return false
+	}
+
+	return true
+}
+
+// conditionMustTerminate checks whether the condition string must be terminated now in order to be a valid condition.
+// Returns true if condition string must be terminated and false otherwise.
+func conditionMustTerminate(suggs []suggestion, prevprev, prev, last string, openParens, dirKeywordCount, nTokens int) bool {
+	// If there are no suggestions, and there is already a previous condition,
+	// and the current condition is a direction filter, the condition string
+	// must end (no other conditions are allowed afterwards).
+	//
+	// Note: This case handles a dir keyword occurring
+	// on the right of a top-level conjunction (potentially
+	// with trailing whitespaces).
+	// (e.g. terminates "sip = 127.0.0.1 & dir = in ",
+	// "sip = 127.0.0.1 & dir = inbound ")
+	if len(suggs) == 0 && nTokens > 3 {
+		for _, direction := range types.DirectionFilters {
+			// If dir is specified on the right side of a top-level conjunction,
+			// do not allow any trailing tokens.
+			if prev == direction && last == "" || last == direction {
+				return true
+			}
+		}
+	}
+
+	// If there is exactly one suggestion, and the current
+	// condition is a direction filter and this suggestion is
+	// exactly what the user specified, the condition string must end.
+	//
+	// Note: This handles termination of condition strings ending
+	// with a direction filter in case there no trailing whitespaces.
+	// (e.g., terminates "sip = 127.0.0.1 & dir = inbound",
+	// "sip = 127.0.0.1 & dir = unidirectional" )
+	if len(suggs) == 1 && nTokens > 3 {
+		for _, direction := range types.DirectionFilters {
+			if suggs[0].token == direction && suggs[0].token == last {
+				return true
+			}
+		}
+	}
+
+	// If there are no suggestions, and the dir keyword
+	// has already occurred, and the current position is
+	// directly after a top level condition with non-empty value,
+	// the condition string must end.
+	// The condition value is only validated for direction filters.
+	// (e.g. terminates "dir = in & sip = 127.0.0.1", BUT also
+	// "dir = in & sip = 42")
+	if len(suggs) == 0 && dirKeywordCount > 0 && openParens == 0 && nTokens > 3 {
+		// for direction filters, validate value
+		if prevprev == types.FilterKeywordDirection || prevprev == types.FilterKeywordDirectionSugared {
+			for _, direction := range types.DirectionFilters {
+				if last == direction {
+					return true
+				}
+			}
+			return false
+		}
+
+		// Ensure that the condition has a non-empty value.
+		switch prev {
+		// Do not auto terminate on incomplete direction filters.
+		case types.FilterKeywordDirection, types.FilterKeywordDirectionSugared:
+			return false
+		case "=", "!=", "<", ">", "<=", ">=", "&", "|":
+			if last == "" {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	// If none of the filters apply, do not auto-terminate.
+	return false
 }

--- a/cmd/goquery_completion/conditional_test.go
+++ b/cmd/goquery_completion/conditional_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type conditionalTest struct {
+	in                   []string
+	expectedNSuggestions int
+}
+
+func testConditionals(t *testing.T, tests []conditionalTest) {
+	for _, test := range tests {
+		suggs := conditional(test.in)
+		nSuggs := len(suggs)
+		require.Equalf(t, test.expectedNSuggestions, nSuggs, "Expected: %d Got: %d", test.expectedNSuggestions, nSuggs)
+	}
+}
+
+func TestConditionalsBasic(t *testing.T) {
+	var conditionalTestsBasic = []conditionalTest{
+		{[]string{""}, 15},
+		{[]string{"!"}, 12},
+		{[]string{"goquery", "-c", "d"}, 6},
+		{[]string{"goquery", "-c", "di"}, 3},
+		{[]string{"goquery", "-c", "dir"}, 2},
+		{[]string{"goquery", "-c", "ds"}, 2},
+		{[]string{"goquery", "-c", "dip"}, 2},
+	}
+
+	testConditionals(t, conditionalTestsBasic)
+}
+
+func TestConditionalsStructure(t *testing.T) {
+	var conditionalStructureTests = []conditionalTest{
+		{[]string{"goquery", "-c", "dire"}, 8},        // direction = {direction values}
+		{[]string{"goquery", "-c", "direction ="}, 8}, // direction = {direction values}
+		{[]string{"goquery", "-c", "dir = i"}, 2},
+		{[]string{"goquery", "-c", "dir = in"}, 2},
+
+		// Complete inbound + only suggest & + don't suggest another dir keyword.
+		{[]string{"goquery", "-c", "dir = inb"}, 14},
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 & dir = inb"}, 1},
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 & dir = inb"}, 1},
+
+		// Suggest dir directly after top-level &.
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 & "}, 15},
+		{[]string{"goquery", "-c", "(sip = 127.0.0.1 & dport = 22) & "}, 15},
+		// Don't suggest dir after non-top-level &.
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 & dport = 22 & "}, 13},
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 & dport = 22 & dir = "}, 2},
+
+		// Don't suggest dir after top-level |.
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 | "}, 13},
+
+		// Don't suggest after invalid condition strings.
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 & dport = 22 & dir = "}, 2},
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 | dir ="}, 2},
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 | dir "}, 2},
+	}
+
+	testConditionals(t, conditionalStructureTests)
+}
+
+func TestConditionalsEdgeCases(t *testing.T) {
+	var conditionalEdgeCasesTests = []conditionalTest{
+
+		// Successful condition string termination.
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 & dir = inbound"}, 1},
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 & dir = inbound "}, 1},
+		{[]string{"goquery", "-c", "dir = out & sip = 127.0.0.1"}, 1},
+		{[]string{"goquery", "-c", "dir = out & (sip = 127.0.0.1 | dport = 22)"}, 1},
+		{[]string{"goquery", "-c", "dir = out & (sip = 127.0.0.1 | dport = 22) "}, 1},
+
+		// Do not terminate condition string.
+		{[]string{"goquery", "-c", "dir = out & (sip = 127.0.0.1 |"}, 13},
+		{[]string{"goquery", "-c", "dir = out "}, 13},
+		{[]string{"goquery", "-c", "dir = inbound & ( dst = 127.0.0.1 & src = 127.0.0.1) &"}, 2},
+		{[]string{"goquery", "-c", "dir = inbound & ( dst = 127.0.0.1 & src = 127.0.0.1) |"}, 2},
+		{[]string{"goquery", "-c", "dir = inbound & ( dst = 127.0.0.1 & src = 127.0.0.1) & "}, 2},
+		{[]string{"goquery", "-c", "dir = inbound & ( dst = 127.0.0.1 & src = 127.0.0.1) | "}, 2},
+
+		// Invalid dir values (yields itself + "can't help" text).
+		{[]string{"goquery", "-c", "dir = inn"}, 2},
+		{[]string{"goquery", "-c", "sip = 127.0.0.1 & dir = inn"}, 2},
+	}
+
+	testConditionals(t, conditionalEdgeCasesTests)
+}

--- a/pkg/e2etest/e2e_test.go
+++ b/pkg/e2etest/e2e_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/els0r/goProbe/pkg/goDB/conditions/node"
-
 	"github.com/els0r/goProbe/cmd/goProbe/config"
 	"github.com/els0r/goProbe/cmd/goQuery/cmd"
 
@@ -32,6 +30,7 @@ import (
 	"github.com/els0r/goProbe/pkg/capture"
 	"github.com/els0r/goProbe/pkg/capture/capturetypes"
 	"github.com/els0r/goProbe/pkg/goDB"
+	"github.com/els0r/goProbe/pkg/goDB/conditions/node"
 	"github.com/els0r/goProbe/pkg/goDB/encoder/encoders"
 	"github.com/els0r/goProbe/pkg/results"
 	"github.com/els0r/goProbe/pkg/types"

--- a/pkg/e2etest/types.go
+++ b/pkg/e2etest/types.go
@@ -5,7 +5,6 @@ package e2etest
 
 import (
 	"context"
-	"github.com/els0r/goProbe/pkg/goDB/conditions/node"
 	"io/fs"
 	"os"
 	"sync"
@@ -16,6 +15,7 @@ import (
 	"github.com/els0r/goProbe/pkg/capture"
 	"github.com/els0r/goProbe/pkg/capture/capturetypes"
 	"github.com/els0r/goProbe/pkg/goDB"
+	"github.com/els0r/goProbe/pkg/goDB/conditions/node"
 	"github.com/els0r/goProbe/pkg/goDB/info"
 	"github.com/els0r/goProbe/pkg/results"
 	"github.com/els0r/goProbe/pkg/types"

--- a/pkg/goDB/conditions/node/filter_direction.go
+++ b/pkg/goDB/conditions/node/filter_direction.go
@@ -3,6 +3,7 @@ package node
 import (
 	"errors"
 	"fmt"
+
 	"github.com/els0r/goProbe/pkg/types"
 	"github.com/els0r/goProbe/pkg/types/hashmap"
 )
@@ -51,7 +52,7 @@ func extractDirectionFilter(node Node) (hashmap.ValFilter, error) {
 			return nil, fmt.Errorf(unsupportedDirectionFilterComparatorStr, node.comparator)
 		}
 		var filter hashmap.ValFilter
-		switch types.FilterTypeDirection(node.value) {
+		switch node.value {
 		case types.FilterTypeDirectionIn, types.FilterTypeDirectionInSugared:
 			filter = types.Counters.IsOnlyInbound
 		case types.FilterTypeDirectionOut, types.FilterTypeDirectionOutSugared:

--- a/pkg/goDB/conditions/node/node.go
+++ b/pkg/goDB/conditions/node/node.go
@@ -23,11 +23,11 @@ package node
 import (
 	"errors"
 	"fmt"
-	"github.com/els0r/goProbe/pkg/types/hashmap"
 	"time"
 
 	"github.com/els0r/goProbe/pkg/goDB/conditions"
 	"github.com/els0r/goProbe/pkg/types"
+	"github.com/els0r/goProbe/pkg/types/hashmap"
 )
 
 const resNil = "<nil>"

--- a/pkg/goDB/conditions/node/node_test.go
+++ b/pkg/goDB/conditions/node/node_test.go
@@ -14,8 +14,9 @@ package node
 import (
 	"errors"
 	"fmt"
-	"github.com/els0r/goProbe/pkg/types"
 	"testing"
+
+	"github.com/els0r/goProbe/pkg/types"
 )
 
 var negationNormalFormTests = []struct {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -106,27 +106,24 @@ const (
 	FilterKeywordNone             = "none"
 )
 
-// FilterTypeDirection denotes filters wrt. directionality of traffic
-type FilterTypeDirection string
-
 const (
 	// incoming but no outgoing packets
-	FilterTypeDirectionIn        FilterTypeDirection = "in"
-	FilterTypeDirectionInSugared FilterTypeDirection = "inbound"
+	FilterTypeDirectionIn        = "in"
+	FilterTypeDirectionInSugared = "inbound"
 	// outgoing but no incoming packets
-	FilterTypeDirectionOut        FilterTypeDirection = "out"
-	FilterTypeDirectionOutSugared FilterTypeDirection = "outbound"
+	FilterTypeDirectionOut        = "out"
+	FilterTypeDirectionOutSugared = "outbound"
 	// either only incoming or only outgoing packets
-	FilterTypeDirectionUni        FilterTypeDirection = "uni"
-	FilterTypeDirectionUniSugared FilterTypeDirection = "unidirectional"
+	FilterTypeDirectionUni        = "uni"
+	FilterTypeDirectionUniSugared = "unidirectional"
 	// both incoming and outgoing packets (excluding unidirectional traffic)
-	FilterTypeDirectionBi        FilterTypeDirection = "bi"
-	FilterTypeDirectionBiSugared FilterTypeDirection = "bidirectional"
+	FilterTypeDirectionBi        = "bi"
+	FilterTypeDirectionBiSugared = "bidirectional"
 )
 
-var DirectionFilters = []FilterTypeDirection{FilterTypeDirectionIn, FilterTypeDirectionInSugared,
-	FilterTypeDirectionOut, FilterTypeDirectionOutSugared, FilterTypeDirectionOutSugared,
-	FilterTypeDirectionUni, FilterTypeDirectionUniSugared, FilterTypeDirectionBi, FilterTypeDirectionBiSugared}
+var DirectionFilters = []string{FilterTypeDirectionIn, FilterTypeDirectionInSugared,
+	FilterTypeDirectionOut, FilterTypeDirectionOutSugared, FilterTypeDirectionUni, FilterTypeDirectionUniSugared,
+	FilterTypeDirectionBi, FilterTypeDirectionBiSugared}
 
 // AnySelector denotes any / all (interfaces, hosts, ...)
 const AnySelector = "any"


### PR DESCRIPTION
This PR provides support for autocompletion of the `{dir|direction}` keyword. 
As the `{dir|direction}` keyword imposes some conditions on the structure of the condition string, we want to ensure that:
- keywords are only suggested when they are applicable
- condition strings are automatically terminated if any additional condition would yield an invalid query

Examples: 
- `dir` is suggested for an empty condition string as well as for `(sip = 127.0.0.1 & port = 22) & ` but not for `sip = 127.0.0.1 & port = 22 & ` (`dir`wouldn't occur at the top-level in this case)
- `sip = 127.0.0.1 & dir = inb` yields the automatically terminated condition string `sip = 127.0.0.1 & dir = inbound`
- `dir = in & sip = 127.0.0.1` is automatically terminated

As this PR contains complex filtering logic, we have added extensive comments, describing each filter.