### PR TITLE
[feature] Improve build pipeline speed

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1,4 +1,4 @@
-name: build-packages
+name: Build Packages
 
 on:
   push:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,18 +1,13 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
-name: Go
+name: CI Build / Test (Push)
 
 on:
-  - push
   - pull_request
 
 jobs:
 
   build-linux:
-    name: Build on Linux
+    name: Build / Test on Linux
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -22,6 +17,15 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
+
+    - name: Build for AMD64
+      run: GOOS=linux GOARCH=amd64 go build -tags jsoniter -v ./...
+
+    - name: Build for AMD64 (Production Mode)
+      run: GOOS=linux GOARCH=amd64 go build -tags jsoniter,slimcap_nomock -v ./...
+
+    - name: Build for AMD64 (No-GCO Mode)
+      run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags jsoniter -v ./...
 
     - name: Test
       run: |
@@ -40,11 +44,4 @@ jobs:
       run: |
         go test -tags jsoniter -race -v ./...
 
-    - name: Build for AMD64
-      run: GOOS=linux GOARCH=amd64 go build -tags jsoniter -v -a ./...
 
-    - name: Build for AMD64 (Production Mode)
-      run: GOOS=linux GOARCH=amd64 go build -tags jsoniter,slimcap_nomock -v -a ./...
-
-    - name: Build for AMD64 (No-GCO Mode)
-      run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags jsoniter -v -a ./...

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,4 +1,4 @@
-name: CI Build / Test (Push)
+name: CI Build / Test (Pull Request)
 
 on:
   - pull_request

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -25,9 +25,3 @@ jobs:
       run: |
         go test -tags jsoniter -v ./... -covermode=atomic -coverprofile=coverage.out
         go tool cover -func=coverage.out -o=coverage.out
-
-    - name: Race Detector
-      run: |
-        go test -tags jsoniter -race -v ./...
-
-

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,0 +1,33 @@
+name: CI Build / Test (Push)
+
+on:
+  - push
+
+jobs:
+
+  build-linux:
+    name: Build / Test on Linux
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ^1.21
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
+    - name: Build for AMD64
+      run: GOOS=linux GOARCH=amd64 go build -tags jsoniter -v ./...
+
+    - name: Test
+      run: |
+        go test -tags jsoniter -v ./... -covermode=atomic -coverprofile=coverage.out
+        go tool cover -func=coverage.out -o=coverage.out
+
+    - name: Race Detector
+      run: |
+        go test -tags jsoniter -race -v ./...
+
+

--- a/pkg/capture/capture_test.go
+++ b/pkg/capture/capture_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/els0r/goProbe/pkg/capture/capturetypes"
 	"github.com/els0r/goProbe/pkg/goDB/encoder/encoders"
 	"github.com/els0r/goProbe/pkg/goprobe/writeout"
+	"github.com/els0r/telemetry/logging"
 	"github.com/fako1024/slimcap/capture"
 	"github.com/fako1024/slimcap/capture/afpacket/afring"
 	"github.com/fako1024/slimcap/link"
@@ -59,6 +60,12 @@ func (t testMockSrcs) Wait() error {
 }
 
 func TestConcurrentMethodAccess(t *testing.T) {
+
+	require.Nil(t, logging.Init(logging.LevelWarn, logging.EncodingLogfmt,
+		logging.WithOutput(os.Stdout),
+		logging.WithErrorOutput(os.Stderr),
+	))
+
 	for _, i := range []int{1, 2, 3, 10} {
 		t.Run(fmt.Sprintf("%d ifaces", i), func(t *testing.T) {
 			testConcurrentMethodAccess(t, i, 1000)

--- a/pkg/capture/capture_test.go
+++ b/pkg/capture/capture_test.go
@@ -368,7 +368,7 @@ func testDeadlockHighTraffic(t *testing.T) {
 		select {
 		case err := <-errChan:
 			doneChan <- err
-		case <-time.After(30 * time.Second):
+		case <-time.After(time.Minute):
 			doneChan <- errors.New("potential deadlock situation on rotation logic (no termination confirmation received from mock source)")
 		}
 
@@ -377,7 +377,7 @@ func testDeadlockHighTraffic(t *testing.T) {
 
 	require.Nil(t, <-doneChan)
 
-	if time.Since(start) > 30*time.Second {
+	if time.Since(start) > 3*time.Minute {
 		t.Fatalf("potential deadlock situation on rotation logic (test took %v)", time.Since(start))
 	}
 }


### PR DESCRIPTION
This brings down the `push` CI run to <5min. I've decided against removing some of the individual tests (using `-short` and the likes) because the _runtime_ of the whole test suite is / was not the limiting factor and I don't see the need to introduce further complexity for the sake of a few seconds of runtime. 

We're now mostly bound by the initial fetch / build of the package, which can't really be sped up I guess.

I've also taken the liberty of doing some cleanup of the output, reducing the terribly high verbosity from some of the tests.

Closes #249 