### PR TITLE
[feature] Optimize legacy v4 conversion tool for large DBs

### DIFF
--- a/pkg/goDB/storage/gpfile/gpdir.go
+++ b/pkg/goDB/storage/gpfile/gpdir.go
@@ -138,10 +138,7 @@ func NewDir(basePath string, timestamp int64, accessMode int, options ...Option)
 		options:     options,
 	}
 
-	dayTimestamp := DirTimestamp(timestamp)
-	dayUnix := time.Unix(dayTimestamp, 0)
-
-	obj.dirPath = filepath.Join(basePath, strconv.Itoa(dayUnix.Year()), fmt.Sprintf("%02d", dayUnix.Month()), strconv.FormatInt(dayTimestamp, 10))
+	obj.dirPath = GenPathForTimestamp(basePath, timestamp)
 	obj.metaPath = filepath.Join(obj.dirPath, metadataFileName)
 	return &obj
 }
@@ -530,6 +527,15 @@ func (d *GPDir) writeMetadataAtomic() error {
 
 func (d *GPDir) setPermissions(permissions fs.FileMode) {
 	d.permissions = permissions
+}
+
+// GenPathForTimestamp provides a unified generator method that allows to construct the path to
+// the data on disk based on a base path and a timestamp
+func GenPathForTimestamp(basePath string, timestamp int64) string {
+	dayTimestamp := DirTimestamp(timestamp)
+	dayUnix := time.Unix(dayTimestamp, 0)
+
+	return filepath.Join(basePath, strconv.Itoa(dayUnix.Year()), fmt.Sprintf("%02d", dayUnix.Month()), strconv.FormatInt(dayTimestamp, 10))
 }
 
 // DirTimestamp returns timestamp rounded down to the nearest directory time frame (usually a day)


### PR DESCRIPTION
This should make in-situ DB conversion much, much easier to facilitate. The changed processing order in combination with the ability to trim data older than a certain timestamp (only affects whole directories / days so we can't "fracture" data) should support the following `YOLO` upgrade flow:

1. Stop `goProbe v3`
2. Upgrade package
3. Run `legacy` tool against `v3` DB (limit to e.g. the last 7 days or so, depending on the volume / patch speed required)
4. Start `goProbe v4` (against newly converted DB)

The patch is done at this point. `goProbe v4` can happily write to the converted partial DB (as it contains all the most recent data) and the patch can terminate.

Immediately after the upgrade completed, re-run the `legacy` tool with the same parameters (maybe less cores as there's no rush anymore) and whatever retention is going to be required for `v4`. This will convert / fill the remaining data into the new DB without touching the already converted part (which is written to by `goProbe v4` in parallel).