### PR TITLE
[bugfix] Remove error type assertion antipattern

### DIFF
--- a/cmd/goQuery/cmd/root.go
+++ b/cmd/goQuery/cmd/root.go
@@ -383,8 +383,8 @@ func entrypoint(cmd *cobra.Command, args []string) (err error) {
 	stmt, err := queryArgs.Prepare()
 	if err != nil {
 		// if there's an args error, print it in a user-friendly way
-		prettyErr, ok := err.(types.Prettier)
-		if ok {
+		var prettyErr types.Prettier
+		if errors.As(err, &prettyErr) {
 			return fmt.Errorf("%s:\n%s", queryPrepFailureMsg, prettyErr.Pretty())
 		}
 		return fmt.Errorf("%s: %w", queryPrepFailureMsg, err)

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -83,10 +84,8 @@ func ValidationHandler() gin.HandlerFunc {
 		_, err := queryArgs.Prepare()
 		if err != nil {
 			vr := &ValidationResponse{StatusCode: http.StatusBadRequest}
-			switch t := err.(type) {
-			case *query.ArgsError:
-				vr.ArgsError = t
-			default:
+
+			if !errors.As(err, &vr.ArgsError) {
 				LogAndAbort(ctx, c, http.StatusInternalServerError, err)
 				return
 			}

--- a/pkg/query/args.go
+++ b/pkg/query/args.go
@@ -276,8 +276,8 @@ func (err *ArgsError) Pretty() string {
 `
 	errStr := err.err.Error()
 
-	prettyErr, ok := err.err.(types.Prettier)
-	if ok {
+	var prettyErr types.Prettier
+	if errors.As(err, &prettyErr) {
 		errStr = "\n" + types.PrettyIndent(prettyErr, 4)
 	}
 

--- a/pkg/query/args_test.go
+++ b/pkg/query/args_test.go
@@ -244,7 +244,8 @@ func TestPrepareArgs(t *testing.T) {
 
 			t.Logf("error:\n%v", err)
 
-			actual, ok := err.(*ArgsError)
+			actual := new(ArgsError)
+			ok := errors.As(err, &actual)
 			require.Truef(t, ok, "expected error to be of type %T", &ArgsError{})
 
 			// individually compare the struct fields. Why the detour? So we don't have


### PR DESCRIPTION
Most were easy enough, just one note: The `.(type)` assertion replacement becomes really nasty if you have a lot of possible types for an error (which luckily isn't the case here) because this cannot be done safely with a switch statement. Instead, one would have to check against each type one by one using `errors.As()`. So in conclusion: Try to avoid... :wink:

Closes #255 