### PR TITLE
[bugfix] Add missing error handling during DB walk

### DIFF
--- a/pkg/goDB/DBWorkManager.go
+++ b/pkg/goDB/DBWorkManager.go
@@ -135,6 +135,9 @@ func (w *DBWorkManager) CreateWorkerJobs(tfirst int64, tlast int64) (nonempty bo
 		return nil
 	}
 	numDirs, err := w.walkDB(tfirst, tlast, walkFunc)
+	if err != nil {
+		return false, err
+	}
 
 	// Flush any remaining work
 	if len(workloadBulk) > 0 {


### PR DESCRIPTION
Note: This might come back to us at some point (e.g. if we encounter some strange corrupted DBs, which might prevent querying, but TBH I'd rather see this instead of having the call silently return incomplete / corrupt data).

Closes #254 