### PR TITLE
[feature] Improve config reload change feedback

### DIFF
--- a/cmd/goProbe/config/monitor.go
+++ b/cmd/goProbe/config/monitor.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/els0r/goProbe/pkg/capture/capturetypes"
 	"github.com/els0r/telemetry/logging"
 )
 
@@ -22,7 +23,7 @@ type Monitor struct {
 }
 
 // CallbackFn denotes a function to be called upon successful reload of the configuration
-type CallbackFn func(context.Context, Ifaces) (enabled, updated, disabled []string, err error)
+type CallbackFn func(context.Context, Ifaces) (enabled, updated, disabled capturetypes.IfaceChanges, err error)
 
 // MonitorOption denotes a functional option for a config monitor
 type MonitorOption func(*Monitor)
@@ -85,7 +86,7 @@ func (m *Monitor) Start(ctx context.Context, fn CallbackFn) {
 }
 
 // Reload triggers a config reload from disk and triggers the execution of the provided callback (if any)
-func (m *Monitor) Reload(ctx context.Context, fn CallbackFn) (enabled, updated, disabled []string, err error) {
+func (m *Monitor) Reload(ctx context.Context, fn CallbackFn) (enabled, updated, disabled capturetypes.IfaceChanges, err error) {
 	cfg, perr := ParseFile(m.path)
 	if perr != nil {
 		err = fmt.Errorf("failed to reload config file: %w", err)
@@ -104,7 +105,7 @@ func (m *Monitor) Reload(ctx context.Context, fn CallbackFn) (enabled, updated, 
 }
 
 // Apply peforms a callback to the provided function and returns its result
-func (m *Monitor) Apply(ctx context.Context, fn CallbackFn) (enabled, updated, disabled []string, err error) {
+func (m *Monitor) Apply(ctx context.Context, fn CallbackFn) (enabled, updated, disabled capturetypes.IfaceChanges, err error) {
 
 	if fn == nil {
 		err = fmt.Errorf("no callback function provided")

--- a/cmd/gpctl/cmd/config.go
+++ b/cmd/gpctl/cmd/config.go
@@ -104,7 +104,7 @@ func configEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
 
 	table := tablewriter.CreateTable()
 	table.UTF8Box()
-	table.AddTitle(shellformat.FormatShell("Interface Configuration", shellformat.Bold))
+	table.AddTitle(shellformat.Fmt(shellformat.Bold, "Interface Configuration"))
 
 	table.AddRow("", "", "ring buffer", "ring buffer")
 	table.AddRow("iface", "promisc", "block size", "num blocks")
@@ -192,7 +192,7 @@ func formatIfaceChanges(ok, failed []string) string {
 
 	// If any changes failed, append a nicely formatted list of those
 	if len(failed) > 0 {
-		output += shellformat.FormatShell(fmt.Sprintf(" (FAILED: %v)", failed), shellformat.Bold, shellformat.Red)
+		output += shellformat.Fmt(shellformat.Bold|shellformat.Red, " (FAILED: %v)", failed)
 	}
 
 	return output

--- a/cmd/gpctl/cmd/config.go
+++ b/cmd/gpctl/cmd/config.go
@@ -179,6 +179,21 @@ func printIfaceChanges(enabled, updated, disabled capturetypes.IfaceChanges) {
      Updated: %s
     Disabled: %s
 
-`, enabled, updated, disabled,
+`, formatIfaceChanges(enabled.Results()),
+		formatIfaceChanges(updated.Results()),
+		formatIfaceChanges(disabled.Results()),
 	)
+}
+
+func formatIfaceChanges(ok, failed []string) string {
+
+	// Start with the successful ones (if any, otherwise print '[]')
+	output := fmt.Sprintf("%v", ok)
+
+	// If any changes failed, append a nicely formatted list of those
+	if len(failed) > 0 {
+		output += shellformat.FormatShell(fmt.Sprintf(" (FAILED: %v)", failed), shellformat.Bold, shellformat.Red)
+	}
+
+	return output
 }

--- a/cmd/gpctl/cmd/config.go
+++ b/cmd/gpctl/cmd/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/els0r/goProbe/cmd/goProbe/config"
 	"github.com/els0r/goProbe/cmd/gpctl/pkg/conf"
 	"github.com/els0r/goProbe/pkg/api/goprobe/client"
+	"github.com/els0r/goProbe/pkg/capture/capturetypes"
 	"github.com/els0r/goProbe/pkg/types/shellformat"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -172,11 +173,11 @@ func updateConfig(ctx context.Context, file string, silent bool) error {
 	return nil
 }
 
-func printIfaceChanges(enabled, updated, disabled []string) {
+func printIfaceChanges(enabled, updated, disabled capturetypes.IfaceChanges) {
 	fmt.Printf(`
-     Enabled: %v
-     Updated: %v
-    Disabled: %v
+     Enabled: %s
+     Updated: %s
+    Disabled: %s
 
 `, enabled, updated, disabled,
 	)

--- a/cmd/gpctl/cmd/status.go
+++ b/cmd/gpctl/cmd/status.go
@@ -90,7 +90,7 @@ func statusEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
 
 	table := tablewriter.CreateTable()
 	table.UTF8Box()
-	table.AddTitle(shellformat.FormatShell("Interface Statuses", shellformat.Bold))
+	table.AddTitle(shellformat.Fmt(shellformat.Bold, "Interface Statuses"))
 
 	headerRow1 := []interface{}{"", "total", "", "total", "", "total", "", "active"}
 	headerRow2 := []interface{}{"iface",
@@ -124,7 +124,7 @@ func statusEntrypoint(ctx context.Context, cmd *cobra.Command, args []string) er
 
 		dropped := fmt.Sprint(formatting.Countable(ifaceStatus.Dropped))
 		if ifaceStatus.Dropped > 0 {
-			dropped = shellformat.FormatShell(ifaceStatus.Dropped, shellformat.Bold, shellformat.Red)
+			dropped = shellformat.Fmt(shellformat.Bold|shellformat.Red, "%d", ifaceStatus.Dropped)
 		}
 
 		ifaceRow := []interface{}{st.iface,

--- a/pkg/api/goprobe/api.go
+++ b/pkg/api/goprobe/api.go
@@ -54,9 +54,9 @@ type ConfigResponse struct {
 // ConfigUpdateResponse is the response to a config update
 type ConfigUpdateResponse struct {
 	response
-	Enabled  []string `json:"enabled"`  // Enabled: stores the interfaces that were enabled. Example: ["eth0", "eth1"]
-	Updated  []string `json:"updated"`  // Updated: stores the interfaces that were updated. Example: ["eth2"]
-	Disabled []string `json:"disabled"` // Disabled: stores the interfaces that were disabled. Example: ["eth5"]
+	Enabled  capturetypes.IfaceChanges `json:"enabled"`  // Enabled: stores the interfaces that were enabled. Example: ["eth0", "eth1"]
+	Updated  capturetypes.IfaceChanges `json:"updated"`  // Updated: stores the interfaces that were updated. Example: ["eth2"]
+	Disabled capturetypes.IfaceChanges `json:"disabled"` // Disabled: stores the interfaces that were disabled. Example: ["eth5"]
 }
 
 // ConfigUpdateRequest is the payload to update the configuration of all

--- a/pkg/api/goprobe/client/config.go
+++ b/pkg/api/goprobe/client/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/els0r/goProbe/cmd/goProbe/config"
 	gpapi "github.com/els0r/goProbe/pkg/api/goprobe"
+	"github.com/els0r/goProbe/pkg/capture/capturetypes"
 	"github.com/fako1024/httpc"
 )
 
@@ -37,7 +38,7 @@ func (c *Client) GetInterfaceConfig(ctx context.Context, ifaces ...string) (ifac
 }
 
 // UpdateInterfaceConfigs updates goprobe's runtime configuration for the provided interfaces
-func (c *Client) UpdateInterfaceConfigs(ctx context.Context, ifaceConfigs config.Ifaces) (enabled, updated, disabled []string, err error) {
+func (c *Client) UpdateInterfaceConfigs(ctx context.Context, ifaceConfigs config.Ifaces) (enabled, updated, disabled capturetypes.IfaceChanges, err error) {
 	var res = new(gpapi.ConfigUpdateResponse)
 
 	url := c.NewURL(gpapi.ConfigRoute)
@@ -58,7 +59,7 @@ func (c *Client) UpdateInterfaceConfigs(ctx context.Context, ifaceConfigs config
 }
 
 // ReloadConfig reads / updates goprobe's runtime configuration with the one from disk
-func (c *Client) ReloadConfig(ctx context.Context) (enabled, updated, disabled []string, err error) {
+func (c *Client) ReloadConfig(ctx context.Context) (enabled, updated, disabled capturetypes.IfaceChanges, err error) {
 	var res = new(gpapi.ConfigUpdateResponse)
 
 	url := c.NewURL(gpapi.ConfigRoute + gpapi.ConfigReloadRoute)

--- a/pkg/api/goprobe/spec/schemas/ConfigUpdateResponse.yaml
+++ b/pkg/api/goprobe/spec/schemas/ConfigUpdateResponse.yaml
@@ -5,18 +5,39 @@ properties:
   enabled:
     type: array
     items:
-      type: string
+      type: object
+      additionalProperties:
+        $ref: './IfaceChange.yaml'
     description: Interfaces that were enabled.
-    example: ["eth0", "eth1"]
+    example:
+      - IfaceChange:
+        name: "eth0"
+        success: true
+      - IfaceChange:
+        name: "eth1"
+        success: false
   updated:
     type: array
     items:
-      type: string
+      type: object
+      additionalProperties:
+        $ref: './IfaceChange.yaml'
     description: Interfaces that were updated.
-    example: ["eth2"]
+    example:
+      - IfaceChange:
+        name: "eth2"
+        success: true
   disabled:
     type: array
     items:
-      type: string
+      type: object
+      additionalProperties:
+        $ref: './IfaceChange.yaml'
     description: Interfaces that were disabled.
-    example: ["eth5"]
+    example:
+      - IfaceChange:
+        name: "eth5"
+        success: true
+      - IfaceChange:
+        name: "eth6"
+        success: false

--- a/pkg/api/goprobe/spec/schemas/IfaceChange.yaml
+++ b/pkg/api/goprobe/spec/schemas/IfaceChange.yaml
@@ -1,0 +1,14 @@
+type: object
+description: IfaceChange denotes the result from a config update / reload of an interface
+required:
+  - name
+  - success
+properties:
+  name:
+    type: string
+    example: eth0
+    description: The name of the interface
+  success:
+    type: boolean
+    example: true
+    description: Indication whether the config update / reload operation(s) succeeded

--- a/pkg/capture/capturetypes/config.go
+++ b/pkg/capture/capturetypes/config.go
@@ -1,0 +1,47 @@
+package capturetypes
+
+import "fmt"
+
+// IfaceChange denotes the result from an interface / config update of an interface
+type IfaceChange struct {
+	Name    string
+	Success bool
+}
+
+// IfaceChanges denotes a list of IfaceChange instances
+type IfaceChanges []IfaceChange
+
+// Names return a simple string slice containing all interface names
+func (c IfaceChanges) Names() []string {
+	names := make([]string, len(c))
+	for i := 0; i < len(c); i++ {
+		names[i] = c[i].Name
+	}
+	return names
+}
+
+// String implements a human-readable output of the IfaceChanges
+func (c IfaceChanges) String() string {
+	var ok, failed []string
+	for _, change := range c {
+		if change.Success {
+			ok = append(ok, change.Name)
+		} else {
+			failed = append(failed, change.Name)
+		}
+	}
+
+	if len(failed) > 0 {
+		return fmt.Sprintf("%v (failed: %v)", ok, failed)
+	}
+	return fmt.Sprintf("%v", ok)
+}
+
+// FromIfaceNames generates a list of IfaceChange instances from a list of interface names
+func FromIfaceNames(names []string) IfaceChanges {
+	res := make(IfaceChanges, len(names))
+	for i := 0; i < len(names); i++ {
+		res[i].Name = names[i]
+	}
+	return res
+}

--- a/pkg/capture/capturetypes/config.go
+++ b/pkg/capture/capturetypes/config.go
@@ -1,9 +1,9 @@
 package capturetypes
 
-// IfaceChange denotes the result from an interface / config update of an interface
+// IfaceChange denotes the result from a config update / reload of an interface
 type IfaceChange struct {
-	Name    string
-	Success bool
+	Name    string // Name: the name of the interface. Example: "eth0"
+	Success bool   // Success: the config update / reload operation(s) succeeded. Example: true
 }
 
 // IfaceChanges denotes a list of IfaceChange instances

--- a/pkg/capture/capturetypes/config.go
+++ b/pkg/capture/capturetypes/config.go
@@ -31,6 +31,21 @@ func (c IfaceChanges) Results() (ok []string, failed []string) {
 	return
 }
 
+// Len returns the length (read: number) of interface changes (implementation of sorting interface)
+func (c IfaceChanges) Len() int {
+	return len(c)
+}
+
+// Less returns if a named change is to be ordered before a second one (implementation of sorting interface)
+func (c IfaceChanges) Less(i, j int) bool {
+	return c[i].Name < c[j].Name
+}
+
+// Swap swaps two interface changes in the list (implementation of sorting interface)
+func (c IfaceChanges) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
 // FromIfaceNames generates a list of IfaceChange instances from a list of interface names
 func FromIfaceNames(names []string) IfaceChanges {
 	res := make(IfaceChanges, len(names))

--- a/pkg/capture/capturetypes/config.go
+++ b/pkg/capture/capturetypes/config.go
@@ -1,7 +1,5 @@
 package capturetypes
 
-import "fmt"
-
 // IfaceChange denotes the result from an interface / config update of an interface
 type IfaceChange struct {
 	Name    string
@@ -20,9 +18,8 @@ func (c IfaceChanges) Names() []string {
 	return names
 }
 
-// String implements a human-readable output of the IfaceChanges
-func (c IfaceChanges) String() string {
-	var ok, failed []string
+// Results return both successful and failed results in a slice, respectively
+func (c IfaceChanges) Results() (ok []string, failed []string) {
 	for _, change := range c {
 		if change.Success {
 			ok = append(ok, change.Name)
@@ -31,10 +28,7 @@ func (c IfaceChanges) String() string {
 		}
 	}
 
-	if len(failed) > 0 {
-		return fmt.Sprintf("%v (failed: %v)", ok, failed)
-	}
-	return fmt.Sprintf("%v", ok)
+	return
 }
 
 // FromIfaceNames generates a list of IfaceChange instances from a list of interface names

--- a/pkg/types/shellformat/shellformat_test.go
+++ b/pkg/types/shellformat/shellformat_test.go
@@ -1,0 +1,81 @@
+package shellformat
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageConsistency(t *testing.T) {
+	require.Equal(t, len(allFormats)-1, int(math.Log2(float64(maxFormat))))
+}
+
+func TestGenerateEscapeSequences(t *testing.T) {
+	type testCase struct {
+		input    Format
+		expected string
+	}
+
+	for _, tc := range []testCase{
+		{
+			input:    0,
+			expected: "",
+		},
+		{
+			input:    Bold,
+			expected: EscapeSeqBold,
+		},
+		{
+			input:    Bold | Red,
+			expected: EscapeSeqBold + EscapeSeqRed,
+		},
+		// Note: It is debatable if supporting multiple colors is reasonable, but it should be general
+		// IMHO and it would require very explicit checks to handle all these special cases
+		{
+			input:    Bold | Red | White,
+			expected: EscapeSeqBold + EscapeSeqRed + EscapeSeqWhite,
+		},
+	} {
+		require.Equal(t, tc.expected, tc.input.genEscapeSeq())
+	}
+}
+
+func TestOutput(t *testing.T) {
+	type testCase struct {
+		format Format
+		input  string
+		a      []any
+
+		expected string
+	}
+
+	// Override isNoColorTerm to allow running the tests anywhere
+	isNoColorTerm = false
+
+	now := time.Now()
+	for _, tc := range []testCase{
+		{
+			format:   0,
+			input:    "",
+			a:        []any{},
+			expected: "",
+		},
+		{
+			format:   Bold,
+			input:    "BoldTest",
+			a:        []any{},
+			expected: EscapeSeqBold + "BoldTest" + EscapeSeqReset,
+		},
+		{
+			format:   Bold | Green,
+			input:    "This number (%d) and this timestamp (%v) are bold green",
+			a:        []any{42, now},
+			expected: EscapeSeqBold + EscapeSeqGreen + fmt.Sprintf("This number (%d) and this timestamp (%v) are bold green", 42, now) + EscapeSeqReset,
+		},
+	} {
+		require.Equal(t, tc.expected, Fmt(tc.format, tc.input, tc.a...))
+	}
+}


### PR DESCRIPTION
Extended API now provides information about success of all interface config changes (using a struct instead of a simple string for each one). Looks like this:
![Screenshot from 2024-02-15 13-59-14](https://github.com/els0r/goProbe/assets/10483969/a990f1d3-8e15-4dd8-9986-3caa01a24979)

Note: If an interface _update_ fails during the `disable` step but then succeeds in the subsequent `enable` step it will show up as successful.

Closes #225 