### PR TITLE
[bugfix][feature] Increase safety of legacy DB conversion tool

### DIFF
--- a/cmd/legacy/main.go
+++ b/cmd/legacy/main.go
@@ -151,7 +151,7 @@ func main() {
 		}
 
 		// Explicitly sort by timestamp (reverse order) to cover potential out-of-order scenarios
-		// an so we convert the latest data first
+		// and so we convert the latest data first
 		sort.Slice(dates, func(i, j int) bool {
 			return dates[i].Name() > dates[j].Name()
 		})


### PR DESCRIPTION
Adds additional cross-checks for the input DB tree.

Closes #263 