### PR TITLE
[bugfix] Remove cyclic calls for Prettier / Pretty() interface & implementation

### DIFF
--- a/cmd/goQuery/cmd/root.go
+++ b/cmd/goQuery/cmd/root.go
@@ -382,12 +382,8 @@ func entrypoint(cmd *cobra.Command, args []string) (err error) {
 	// convert the command line parameters
 	stmt, err := queryArgs.Prepare()
 	if err != nil {
-		// if there's an args error, print it in a user-friendly way
-		var prettyErr types.Prettier
-		if errors.As(err, &prettyErr) {
-			return fmt.Errorf("%s:\n%s", queryPrepFailureMsg, prettyErr.Pretty())
-		}
-		return fmt.Errorf("%s: %w", queryPrepFailureMsg, err)
+		// if there's an args error, try to print it in a user-friendly way
+		return types.ShouldPretty(err, queryPrepFailureMsg)
 	}
 
 	if queryLogFile != "" {

--- a/pkg/query/args.go
+++ b/pkg/query/args.go
@@ -276,11 +276,6 @@ func (err *ArgsError) Pretty() string {
 `
 	errStr := err.err.Error()
 
-	var prettyErr types.Prettier
-	if errors.As(err, &prettyErr) {
-		errStr = "\n" + types.PrettyIndent(prettyErr, 4)
-	}
-
 	return fmt.Sprintf(str, err.Field, err.Message, errStr)
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/netip"
 	"strings"
@@ -189,6 +190,15 @@ func IPStringToBytes(ip string) (ipData []byte, isIPv4 bool, err error) {
 // the output directly
 type Prettier interface {
 	Pretty() string
+}
+
+// ShouldPretty attempts to pretty-print an error (if it fulfills the Prettier interface)
+func ShouldPretty(err error, msg string) error {
+	var prettyErr Prettier
+	if errors.As(err, &prettyErr) {
+		return fmt.Errorf("%s:\n%s", msg, prettyErr.Pretty())
+	}
+	return fmt.Errorf("%s: %w", msg, err)
 }
 
 // PrettyIndent takes the output from a Prettier and indents it by n spaces


### PR DESCRIPTION
This gets rid of the crashes. However TBH I'm not supa happy with the current setup, mostly because it's inconsistent. There are places where it's asserted if an error is a `Prettier`, then a few lines later an error is generated that just assumes to be. We should revisit the whole console output / pretty / non-pretty concept IMHO at some point (and be as generic as possible, adding a few helper functions maybe to make our lives easier).