### PR TITLE
[bugfix] Improve handling of context cancel in DBWorkManager to be more responsive

### DIFF
--- a/pkg/goDB/DBWorkManager.go
+++ b/pkg/goDB/DBWorkManager.go
@@ -480,7 +480,7 @@ func (w *DBWorkManager) grabAndProcessWorkload(ctx context.Context, wg *sync.Wai
 				case <-ctx.Done():
 
 					// query was cancelled, exit
-					logger.Infof("Query cancelled (workload %d / %d)...", w.nWorkloadsProcessed.Load(), w.nWorkloads)
+					logger.Infof("query cancelled (workload %d / %d)...", w.nWorkloadsProcessed.Load(), w.nWorkloads)
 					return
 				default:
 

--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -198,7 +198,7 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 	result.Summary.Last = tSpanLast
 
 	// If enabled, run a live query in the background / parallel to the DB query and put the results on the same output channel
-	liveQueryWG := qr.runLiveQuery(ctx, mapChan, stmt)
+	liveQueryWG := qr.runLiveQuery(queryCtx, mapChan, stmt)
 
 	// spawn reader processing units and make them work on the individual DB blocks
 	// processing by interface is sequential, e.g. for multi-interface queries


### PR DESCRIPTION
Moves handling of context termination down one layer into the processing loop to be able to cancel more quickly.

Closes #273 