### PR TITLE
[bugfix] Fix access beyond IP layer bounds if packet stops right after it

### DIFF
--- a/pkg/capture/flow.go
+++ b/pkg/capture/flow.go
@@ -71,7 +71,7 @@ func ParsePacket(ipLayer capture.IPLayer) (epHash capturetypes.EPHash, isIPv4 bo
 	var protocol byte
 	if ipLayerType := ipLayer.Type(); ipLayerType == ipLayerTypeV4 {
 
-		_ = ipLayer[ipv4.HeaderLen] // bounds check hint to compiler
+		_ = ipLayer[ipv4.HeaderLen-1] // bounds check hint to compiler
 
 		isIPv4, protocol = true, ipLayer[9]
 
@@ -126,7 +126,7 @@ func ParsePacket(ipLayer capture.IPLayer) (epHash capturetypes.EPHash, isIPv4 bo
 		}
 	} else if ipLayerType == ipLayerTypeV6 {
 
-		_ = ipLayer[ipv6.HeaderLen] // bounds check hint to compiler
+		_ = ipLayer[ipv6.HeaderLen-1] // bounds check hint to compiler
 
 		protocol = ipLayer[6]
 


### PR DESCRIPTION
Fixed potential out-of-bounds access and added test for the encountered special (invalid) IP packet scenario.

I'm also trying to capture an actual small `pcap` file on the host in question to get a sample for the E2E tests, but didn't happen again so far... :see_no_evil: 

Performance is actually slightly better (probably because the hint now is more accurate for everything that happens in the function):
```
                                                 │ /tmp/old.txt │            /tmp/new.txt            │
                                                 │    sec/op    │   sec/op     vs base               │
Population/0.0.0.0:68->255.255.255.255:67_17_0-4    9.681n ± 1%   9.514n ± 1%  -1.73% (p=0.000 n=25)
```

Nice catch!


Closes #279 