### PR TITLE
[bugfix] Fix incorrect Prometheus error counters

### DIFF
--- a/pkg/capture/capturetypes/parsing_error.go
+++ b/pkg/capture/capturetypes/parsing_error.go
@@ -42,7 +42,7 @@ func (e ParsingErrno) ParsingFailed() bool {
 type ParsingErrTracker [NumParsingErrors]int
 
 // Sum returns the sum of all errors currently tracked in the error table
-func (e ParsingErrTracker) Sum() (res int) {
+func (e *ParsingErrTracker) Sum() (res int) {
 	for i := ErrnoInvalidIPHeader; i < NumParsingErrors; i++ {
 		res += e[i]
 	}
@@ -50,7 +50,7 @@ func (e ParsingErrTracker) Sum() (res int) {
 }
 
 // Reset resets all error counters in the error table (for reuse)
-func (e ParsingErrTracker) Reset() {
+func (e *ParsingErrTracker) Reset() {
 	for i := ErrnoInvalidIPHeader; i < NumParsingErrors; i++ {
 		e[i] = 0
 	}

--- a/pkg/capture/capturetypes/parsing_error_test.go
+++ b/pkg/capture/capturetypes/parsing_error_test.go
@@ -1,0 +1,26 @@
+package capturetypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResetParsingError(t *testing.T) {
+
+	errs := ParsingErrTracker{}
+
+	errs[ErrnoInvalidIPHeader] = 1
+	errs[ErrnoPacketTruncated] = 2
+
+	require.Equal(t, 1, errs[ErrnoInvalidIPHeader])
+	require.Equal(t, 2, errs[ErrnoPacketTruncated])
+	require.Equal(t, errs.Sum(), 3)
+
+	errs.Reset()
+
+	require.Equal(t, 0, errs[ErrnoInvalidIPHeader])
+	require.Equal(t, 0, errs[ErrnoPacketTruncated])
+	require.Equal(t, errs.Sum(), 0)
+
+}

--- a/pkg/capture/metrics.go
+++ b/pkg/capture/metrics.go
@@ -91,10 +91,10 @@ func init() {
 	)
 }
 
-// ResetCounters allows to externally reset all Prometheus counters (e.g. for testing purposes
-// or in order to manually reset all of them)
+// ResetCountersTestingOnly allows to externally reset all Prometheus counters (e.g. for
+// testing purposes or in order to manually reset all of them)
 // This method must not (and cannot) be called outside of testing
-func ResetCounters() {
+func ResetCountersTestingOnly() {
 
 	// Check if we are actually calling this function from test code
 	if !testing.Testing() {

--- a/pkg/capture/metrics.go
+++ b/pkg/capture/metrics.go
@@ -88,3 +88,14 @@ func init() {
 		promRotationDuration,
 	)
 }
+
+// ResetCounters allows to externally reset all Prometheus counters (e.g. for testing purposes
+// or in order to manually reset all of them)
+func ResetCounters() {
+	promPacketsProcessed.Reset()
+	promBytes.Reset()
+	promPackets.Reset()
+	promNumFlows.Reset()
+	promPacketsDropped.Reset()
+	promCaptureErrors.Reset()
+}

--- a/pkg/capture/metrics.go
+++ b/pkg/capture/metrics.go
@@ -1,6 +1,8 @@
 package capture
 
 import (
+	"testing"
+
 	"github.com/els0r/goProbe/cmd/goProbe/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -91,7 +93,14 @@ func init() {
 
 // ResetCounters allows to externally reset all Prometheus counters (e.g. for testing purposes
 // or in order to manually reset all of them)
+// This method must not (and cannot) be called outside of testing
 func ResetCounters() {
+
+	// Check if we are actually calling this function from test code
+	if !testing.Testing() {
+		panic("cannot reset counter from non-testing code")
+	}
+
 	promPacketsProcessed.Reset()
 	promBytes.Reset()
 	promPackets.Reset()

--- a/pkg/e2etest/e2e_test.go
+++ b/pkg/e2etest/e2e_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/els0r/goProbe/cmd/goProbe/config"
 	"github.com/els0r/goProbe/cmd/goQuery/cmd"
 	"github.com/els0r/telemetry/logging"
+	"github.com/prometheus/client_golang/prometheus"
 
 	// "github.com/els0r/goProbe/cmd/goQuery/commands"
 
@@ -362,6 +363,40 @@ func testE2E(t *testing.T, valFilterDescriptor int, datasets ...[]byte) {
 			resGoQuery.Rows[i].Counters)
 	}
 	require.EqualValues(t, refRows, resRows)
+
+	// Cross-check metrics collected by Prometheus for consistency
+	validateMetrics(t, mockIfaces)
+}
+
+func validateMetrics(t *testing.T, mockIfaces mockIfaces) {
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	require.Nil(t, err)
+
+	for _, metric := range metrics {
+		switch metric.GetName() {
+		case "packets_processed_total":
+			var sum float64
+			for _, metricVal := range metric.Metric {
+				sum += metricVal.Counter.GetValue()
+			}
+			require.Equal(t, float64(mockIfaces.NProcessed()), sum)
+		case "goprobe_capture_errors_total":
+			var sum float64
+			for _, metricVal := range metric.Metric {
+				sum += metricVal.Counter.GetValue()
+			}
+			require.Equal(t, float64(mockIfaces.NErrTracked()), sum)
+		case "packets_dropped_total":
+			var sum float64
+			for _, metricVal := range metric.Metric {
+				sum += metricVal.Counter.GetValue()
+			}
+			require.Zero(t, sum)
+		}
+	}
+
+	// Reset all Prometheus counters for the next E2E test to avoid double counting
+	capture.ResetCounters()
 }
 
 func runGoProbe(t *testing.T, testDir string, sourceInitFn func() (mockIfaces, func(c *capture.Capture) (capture.Source, error))) chan hashmap.AggFlowMapWithMetadata {
@@ -502,6 +537,9 @@ func newPcapSource(t testing.TB, name string, data []byte) (res *mockIface) {
 			hash, isIPv4, auxInfo, errno := capture.ParsePacket(pkt.IPLayer())
 			if errno > capturetypes.ErrnoOK {
 				res.tracking.nErr++
+				if errno != capturetypes.ErrnoPacketFragmentIgnore {
+					res.tracking.nErrTracked++
+				}
 				return
 			}
 			if errno != capturetypes.ErrnoPacketFragmentIgnore {

--- a/pkg/e2etest/e2e_test.go
+++ b/pkg/e2etest/e2e_test.go
@@ -396,7 +396,7 @@ func validateMetrics(t *testing.T, mockIfaces mockIfaces) {
 	}
 
 	// Reset all Prometheus counters for the next E2E test to avoid double counting
-	capture.ResetCounters()
+	capture.ResetCountersTestingOnly()
 }
 
 func runGoProbe(t *testing.T, testDir string, sourceInitFn func() (mockIfaces, func(c *capture.Capture) (capture.Source, error))) chan hashmap.AggFlowMapWithMetadata {

--- a/pkg/e2etest/types.go
+++ b/pkg/e2etest/types.go
@@ -25,9 +25,10 @@ import (
 )
 
 type mockTracking struct {
-	nRead      uint64
-	nProcessed uint64
-	nErr       uint64
+	nRead       uint64
+	nProcessed  uint64
+	nErr        uint64
+	nErrTracked uint64
 
 	done chan struct{}
 }
@@ -112,6 +113,15 @@ func (m mockIfaces) NErr() (res uint64) {
 	for _, v := range m {
 		v.RLock()
 		res += v.tracking.nErr
+		v.RUnlock()
+	}
+	return
+}
+
+func (m mockIfaces) NErrTracked() (res uint64) {
+	for _, v := range m {
+		v.RLock()
+		res += v.tracking.nErrTracked
 		v.RUnlock()
 	}
 	return


### PR DESCRIPTION
As expected, related to a value receiver :see_no_evil:

Took the opportunity to improve the whole E2E suite by further consistency checks (now also cross-checking the most important Prometheus counters).

Closes #281 