### PR TITLE
[bugfix] Make sure that the interface selector is set on `args.Prepare()`

### DIFF
--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -96,8 +96,6 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 		return res, fmt.Errorf("failed to parse query type: %w", err)
 	}
 
-	// make sure that the interface label is added if a query contains
-
 	// build condition tree to check if there is a syntax error before starting processing
 	queryConditional, valFilterNode, parseErr := node.ParseAndInstrument(stmt.Condition, stmt.DNSResolution.Timeout)
 	if parseErr != nil {

--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"regexp"
 	"runtime"
 	"runtime/debug"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -97,6 +95,8 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 	if err != nil {
 		return res, fmt.Errorf("failed to parse query type: %w", err)
 	}
+
+	// make sure that the interface label is added if a query contains
 
 	// build condition tree to check if there is a syntax error before starting processing
 	queryConditional, valFilterNode, parseErr := node.ParseAndInstrument(stmt.Condition, stmt.DNSResolution.Timeout)
@@ -360,34 +360,10 @@ func parseIfaceList(dbPath string, ifaceList string) ([]string, error) {
 		return ifaces, nil
 	}
 
-	ifaces, err := validateIfaceNames(ifaceList)
+	ifaces, err := types.ValidateIfaceNames(ifaceList)
 	if err != nil {
 		return nil, err
 	}
 
-	return ifaces, nil
-}
-
-var ifaceNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9\.:_-]{1,15}$`)
-
-func validateIfaceName(iface string) error {
-	if iface == "" {
-		return errors.New("interface list contains empty interface name")
-	}
-
-	if !ifaceNameRegexp.MatchString(iface) {
-		return fmt.Errorf("interface name `%s` is invalid", iface)
-	}
-
-	return nil
-}
-
-func validateIfaceNames(ifaceList string) ([]string, error) {
-	ifaces := strings.Split(ifaceList, ",")
-	for _, iface := range ifaces {
-		if err := validateIfaceName(iface); err != nil {
-			return nil, err
-		}
-	}
 	return ifaces, nil
 }

--- a/pkg/goDB/engine/query_test.go
+++ b/pkg/goDB/engine/query_test.go
@@ -161,7 +161,7 @@ func TestInterfaceValidation(t *testing.T) {
 	// run table-driven test
 	for _, test := range tests {
 		t.Run(test.iface, func(t *testing.T) {
-			err := validateIfaceName(test.iface)
+			err := types.ValidateIfaceName(test.iface)
 			if test.expectedErr != nil {
 				if err == nil || err.Error() != test.expectedErr.Error() {
 					t.Fatalf("unexpected result for interface name validation: %s", err)

--- a/pkg/query/args.go
+++ b/pkg/query/args.go
@@ -339,6 +339,7 @@ func (a *Args) LogValue() slog.Value {
 }
 
 const (
+	emptyInterfaceMsg              = "empty interface name"
 	invalidInterfaceMsg            = "invalid interface name"
 	invalidQueryTypeMsg            = "invalid query type"
 	invalidFormatMsg               = "unknown format"
@@ -409,7 +410,7 @@ func (a *Args) Prepare(writers ...io.Writer) (*Statement, error) {
 	if a.Ifaces == "" {
 		err := newArgsError(
 			"iface",
-			invalidInterfaceMsg,
+			emptyInterfaceMsg,
 			&types.ParseError{
 				Description: "empty input",
 			},

--- a/pkg/query/args.go
+++ b/pkg/query/args.go
@@ -339,6 +339,7 @@ func (a *Args) LogValue() slog.Value {
 }
 
 const (
+	invalidInterfaceMsg            = "invalid interface name"
 	invalidQueryTypeMsg            = "invalid query type"
 	invalidFormatMsg               = "unknown format"
 	invalidSortByMsg               = "unknown format"
@@ -404,10 +405,30 @@ func (a *Args) Prepare(writers ...io.Writer) (*Statement, error) {
 
 	}
 
+	// set and validate the interfaces
+	if a.Ifaces == "" {
+		err := newArgsError(
+			"iface",
+			invalidInterfaceMsg,
+			&types.ParseError{
+				Description: "empty input",
+			},
+		)
+		return s, err
+	}
+	s.Ifaces, err = types.ValidateIfaceNames(a.Ifaces)
+	if err != nil {
+		return s, newArgsError(
+			"iface",
+			invalidInterfaceMsg,
+			err,
+		)
+	}
+
 	// insert iface attribute here in case multiple interfaces where specified and the
 	// interface column was not added as an attribute
 	if (len(s.Ifaces) > 1 || strings.Contains(a.Ifaces, types.AnySelector)) &&
-		!strings.Contains(a.Query, "iface") {
+		!strings.Contains(a.Query, types.IfaceName) {
 		selector.Iface = true
 	}
 	s.LabelSelector = selector

--- a/pkg/query/args_test.go
+++ b/pkg/query/args_test.go
@@ -275,7 +275,7 @@ func TestSelector(t *testing.T) {
 			selector: types.LabelSelector{},
 			err: &ArgsError{
 				Field:   "iface",
-				Message: invalidInterfaceMsg,
+				Message: emptyInterfaceMsg,
 				Type:    "*types.ParseError",
 			},
 		},

--- a/pkg/types/iface.go
+++ b/pkg/types/iface.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var ifaceNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9\.:_-]{1,15}$`)
+
+func ValidateIfaceName(iface string) error {
+	if iface == "" {
+		return errors.New("interface list contains empty interface name")
+	}
+
+	if !ifaceNameRegexp.MatchString(iface) {
+		return fmt.Errorf("interface name `%s` is invalid", iface)
+	}
+
+	return nil
+}
+
+func ValidateIfaceNames(ifaceList string) ([]string, error) {
+	ifaces := strings.Split(ifaceList, ",")
+	for _, iface := range ifaces {
+		if err := ValidateIfaceName(iface); err != nil {
+			return nil, err
+		}
+	}
+	return ifaces, nil
+}


### PR DESCRIPTION
The side-effect before was that it wasn't set, leading to the interface attribute not being present in the output when >1 interfaces were part of a query.

Also:
* instrument each per-interface processing with a span

Closes #288 