### PR TITLE
[bugfix] Fix help output for supported timestamps (to actually support all of them)

### DIFF
--- a/cmd/goQuery/cmd/help_test.go
+++ b/cmd/goQuery/cmd/help_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/els0r/goProbe/pkg/query"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimestampHelp(t *testing.T) {
+	require.NotPanics(t, func() {
+		_ = buildTimestampHelpList(
+			query.TimeFormatsDefault(),
+			query.TimeFormatsCustom(),
+			query.TimeFormatsRelative(),
+		)
+	})
+}

--- a/pkg/query/time.go
+++ b/pkg/query/time.go
@@ -22,62 +22,90 @@ import (
 	"github.com/els0r/goProbe/pkg/types"
 )
 
-// TimeFormats stores all supported tie formats
-var timeFormats = []string{
-	time.RFC3339, // "2006-01-02T15:04:05Z07:00"
-	time.ANSIC,   // "Mon Jan _2 15:04:05 2006"
+// TimeFormat denotes a time format with an optional verbose name for display
+type TimeFormat struct {
+	Name   string
+	Format string
+}
 
-	time.RubyDate, // "Mon Jan 02 15:04:05 -0700 2006"
-	time.RFC822Z,  // "02 Jan 06 15:04 -0700" // RFC822 with numeric zone
-	time.RFC1123Z, // "Mon, 02 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
+var (
+	timeFormatsDefault = []TimeFormat{
+		{"RFC3339", time.RFC3339},                    // "2006-01-02T15:04:05Z07:00"
+		{"ANSIC", time.ANSIC},                        // "Mon Jan _2 15:04:05 2006"
+		{"RUBY DATE", time.RubyDate},                 // "Mon Jan 02 15:04:05 -0700 2006"
+		{"RFC822 with numeric zone", time.RFC822Z},   // "02 Jan 06 15:04 -0700" // RFC822 with numeric zone
+		{"RFC1123 with numeric zone", time.RFC1123Z}, // "Mon, 02 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
+	}
 
-	types.DefaultTimeOutputFormat,
+	timeFormatsCustom = []TimeFormat{
+		{"CUSTOM", types.DefaultTimeOutputFormat},
 
-	// custom additions
-	"2006-01-02 15:04:05 -0700",
-	"2006-01-02 15:04 -0700",
-	"2006-01-02 15:04:05",
-	"2006-01-02 15:04",
-	"06-01-02 15:04:05 -0700",
-	"06-01-02 15:04 -0700",
-	"06-01-02 15:04:05",
-	"06-01-02 15:04",
-	"02-01-2006 15:04:05 -0700",
-	"02-01-2006 15:04 -0700",
-	"02-01-2006 15:04:05",
-	"02-01-2006 15:04",
-	"02-01-06 15:04:05 -0700",
-	"02-01-06 15:04 -0700",
-	"02-01-06 15:04:05",
-	"02-01-06 15:04",
-	"02.01.2006 15:04",
-	"02.01.2006 15:04 -0700",
-	"02.01.06 15:04",
-	"02.01.06 15:04 -0700",
-	"2.1.06 15:04:05",
-	"2.1.06 15:04:05 -0700",
-	"2.1.06 15:04",
-	"2.1.06 15:04 -0700",
-	"2.1.2006 15:04:05",
-	"2.1.2006 15:04:05 -0700",
-	"2.1.2006 15:04",
-	"2.1.2006 15:04 -0700",
-	"02.1.2006 15:04:05",
-	"02.1.2006 15:04:05 -0700",
-	"02.1.2006 15:04",
-	"02.1.2006 15:04 -0700",
-	"2.01.2006 15:04:05",
-	"2.01.2006 15:04:05 -0700",
-	"2.01.2006 15:04",
-	"2.01.2006 15:04 -0700",
-	"02.1.06 15:04:05",
-	"02.1.06 15:04:05 -0700",
-	"02.1.06 15:04",
-	"02.1.06 15:04 -0700",
-	"2.01.06 15:04:05",
-	"2.01.06 15:04:05 -0700",
-	"2.01.06 15:04",
-	"2.01.06 15:04 -0700",
+		// unnamed additions
+		{"", "2006-01-02 15:04:05 -0700"},
+		{"", "2006-01-02 15:04 -0700"},
+		{"", "2006-01-02 15:04:05"},
+		{"", "2006-01-02 15:04"},
+		{"", "06-01-02 15:04:05 -0700"},
+		{"", "06-01-02 15:04 -0700"},
+		{"", "06-01-02 15:04:05"},
+		{"", "06-01-02 15:04"},
+		{"", "02-01-2006 15:04:05 -0700"},
+		{"", "02-01-2006 15:04 -0700"},
+		{"", "02-01-2006 15:04:05"},
+		{"", "02-01-2006 15:04"},
+		{"", "02-01-06 15:04:05 -0700"},
+		{"", "02-01-06 15:04 -0700"},
+		{"", "02-01-06 15:04:05"},
+		{"", "02-01-06 15:04"},
+		{"", "02.01.2006 15:04"},
+		{"", "02.01.2006 15:04 -0700"},
+		{"", "02.01.06 15:04"},
+		{"", "02.01.06 15:04 -0700"},
+		{"", "2.1.06 15:04:05"},
+		{"", "2.1.06 15:04:05 -0700"},
+		{"", "2.1.06 15:04"},
+		{"", "2.1.06 15:04 -0700"},
+		{"", "2.1.2006 15:04:05"},
+		{"", "2.1.2006 15:04:05 -0700"},
+		{"", "2.1.2006 15:04"},
+		{"", "2.1.2006 15:04 -0700"},
+		{"", "02.1.2006 15:04:05"},
+		{"", "02.1.2006 15:04:05 -0700"},
+		{"", "02.1.2006 15:04"},
+		{"", "02.1.2006 15:04 -0700"},
+		{"", "2.01.2006 15:04:05"},
+		{"", "2.01.2006 15:04:05 -0700"},
+		{"", "2.01.2006 15:04"},
+		{"", "2.01.2006 15:04 -0700"},
+		{"", "02.1.06 15:04:05"},
+		{"", "02.1.06 15:04:05 -0700"},
+		{"", "02.1.06 15:04"},
+		{"", "02.1.06 15:04 -0700"},
+		{"", "2.01.06 15:04:05"},
+		{"", "2.01.06 15:04:05 -0700"},
+		{"", "2.01.06 15:04"},
+		{"", "2.01.06 15:04 -0700"},
+	}
+
+	timeFormatsRelative = []TimeFormat{
+		{"RELATIVE", "-15d:04h:05m"},
+		{"", "-15d4h5m"},
+	}
+)
+
+// TimeFormatsDefault returns a list of all supported default time formats
+func TimeFormatsDefault() []TimeFormat {
+	return timeFormatsDefault
+}
+
+// TimeFormatsCustom returns a list of all supported custom time formats
+func TimeFormatsCustom() []TimeFormat {
+	return timeFormatsCustom
+}
+
+// TimeFormatsRelative returns a list of all supported relative time formats
+func TimeFormatsRelative() []TimeFormat {
+	return timeFormatsRelative
 }
 
 // function returning a UNIX timestamp relative to the current time
@@ -224,8 +252,8 @@ func ParseTimeArgument(timeString string) (int64, error) {
 	}
 
 	// then check other time formats
-	for _, tFormat := range timeFormats {
-		t, err = time.ParseInLocation(tFormat, timeString, loc)
+	for _, tFormat := range append(timeFormatsDefault, timeFormatsCustom...) {
+		t, err = time.ParseInLocation(tFormat.Format, timeString, loc)
 		if err == nil {
 			return t.Unix(), nil
 		}

--- a/pkg/query/time_test.go
+++ b/pkg/query/time_test.go
@@ -9,25 +9,25 @@ import (
 )
 
 func TestParseTimestamp(t *testing.T) {
-	var tests = []string{
+	var tests = []TimeFormat{
 		// special cases
-		"-100000d",
-		"-100000h",
-		"-100000m",
-		"-100000s",
-		"-23d:4h:3m",
-		"-23d:4h:8m:3s",
-		"-23d4h8m3s",
-		"1674492267",
-		"2006-01-02T15:04:05-07:00",             // RFC3339 test
-		"Mon Jan 23 11:31:04 2023",              // ANSIC test
-		fmt.Sprintf("%d", types.MaxTime.Unix()), // Maximum supported time
+		{"", "-100000d"},
+		{"", "-100000h"},
+		{"", "-100000m"},
+		{"", "-100000s"},
+		{"", "-23d:4h:3m"},
+		{"", "-23d:4h:8m:3s"},
+		{"", "-23d4h8m3s"},
+		{"", "1674492267"},
+		{"", "2006-01-02T15:04:05-07:00"},             // RFC3339 test
+		{"", "Mon Jan 23 11:31:04 2023"},              // ANSIC test
+		{"", fmt.Sprintf("%d", types.MaxTime.Unix())}, // Maximum supported time
 	}
-	tests = append(tests, timeFormats[2:]...)
+	tests = append(tests, append(timeFormatsDefault, timeFormatsCustom...)[2:]...)
 
-	for _, tStr := range tests {
-		t.Run(tStr, func(t *testing.T) {
-			tstamp, err := ParseTimeArgument(tStr)
+	for _, tFormat := range tests {
+		t.Run(tFormat.Format, func(t *testing.T) {
+			tstamp, err := ParseTimeArgument(tFormat.Format)
 
 			assert.Nil(t, err, "unexpected error: %v", err)
 			assert.NotEqual(t, tstamp, 0, "expected non-zero timestamp")


### PR DESCRIPTION
Now looks like this (always uses current timestamp of help call):
```
...
-f, --first string                        Upper/lower bound on flow timestamp
                                            
                                            DEFAULTS
                                            
                                              --first will default to the last 30 days if not provided. In case
                                              a "time" attribute is involved (e.g. for "time" or "raw" queries),
                                              the default is lowered to the last 24 hours. This is to protect
                                              against accidentally querying the entire database.
                                            
                                              --last will default to the current time if not provided
                                            
                                            ALLOWED FORMATS
                                            
                                              2024-04-14T12:07:21+02:00                     RFC3339
                                              Sun Apr 14 12:07:21 2024                      ANSIC
                                              Sun Apr 14 12:07:21 +0200 2024                RUBY DATE
                                              14 Apr 24 12:07 +0200                         RFC822 with numeric zone
                                              Sun, 14 Apr 2024 12:07:21 +0200               RFC1123 with numeric zone
                                                                                            
                                              2024-04-14 12:07:21                           CUSTOM
                                              2024-04-14 12:07:21 +0200                     
                                              2024-04-14 12:07 +0200                        
                                              2024-04-14 12:07:21                           
                                              2024-04-14 12:07                              
                                              24-04-14 12:07:21 +0200                       
                                              24-04-14 12:07 +0200                          
                                              24-04-14 12:07:21                             
                                              24-04-14 12:07                                
                                              14-04-2024 12:07:21 +0200                     
                                              14-04-2024 12:07 +0200                        
                                              14-04-2024 12:07:21                           
                                              14-04-2024 12:07                              
                                              14-04-24 12:07:21 +0200                       
                                              14-04-24 12:07 +0200                          
                                              14-04-24 12:07:21                             
                                              14-04-24 12:07                                
                                              14.04.2024 12:07                              
                                              14.04.2024 12:07 +0200                        
                                              14.04.24 12:07                                
                                              14.04.24 12:07 +0200                          
                                              14.4.24 12:07:21                              
                                              14.4.24 12:07:21 +0200                        
                                              14.4.24 12:07                                 
                                              14.4.24 12:07 +0200                           
                                              14.4.2024 12:07:21                            
                                              14.4.2024 12:07:21 +0200                      
                                              14.4.2024 12:07                               
                                              14.4.2024 12:07 +0200                         
                                              14.4.2024 12:07:21                            
                                              14.4.2024 12:07:21 +0200                      
                                              14.4.2024 12:07                               
                                              14.4.2024 12:07 +0200                         
                                              14.04.2024 12:07:21                           
                                              14.04.2024 12:07:21 +0200                     
                                              14.04.2024 12:07                              
                                              14.04.2024 12:07 +0200                        
                                              14.4.24 12:07:21                              
                                              14.4.24 12:07:21 +0200                        
                                              14.4.24 12:07                                 
                                              14.4.24 12:07 +0200                           
                                              14.04.24 12:07:21                             
                                              14.04.24 12:07:21 +0200                       
                                              14.04.24 12:07                                
                                              14.04.24 12:07 +0200                          
                                                                                            
                                              -12d:07h:21m                                  RELATIVE
                                              -12d7h21m                                     
                                            
                                            Relative time will be evaluated with respect to NOW. The call can
                                            be varied to include any (integer) combination of days (d), hours
                                            (h) and minutes (m), e.g.
                                            
                                              -15d:04h:05m, -15d:5m, -15d, -5m, -4h, -4h:05m, etc.
...
```

Closes #299 