### PR TITLE
[feature] Reduce verbosity of interface listing and host statuses in global query output

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.21-bullseye
+FROM mcr.microsoft.com/devcontainers/go:1.22-bullseye
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install git \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -54,8 +54,7 @@
         },
         "gopls": {
           "usePlaceholders": false,
-          "staticcheck": true,
-          "vulncheck": "Imports"
+          "staticcheck": true
         },
         "remote.extensionKind": {
           "ms-azuretools.vscode-docker": "workspace"

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ cmd/legacy/legacy
 .vscode/
 _build/
 go.work.sum
-
+.db/

--- a/cmd/goQuery/cmd/root.go
+++ b/cmd/goQuery/cmd/root.go
@@ -431,7 +431,7 @@ func entrypoint(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 		for _, host := range result.HostsStatuses.GetErrorStatuses() {
-			logger.Errorf("Host %s returned with status %q: %s", host.Hostname, host.Code, host.Message)
+			logger.Errorf("Host %s returned with error %q: %s", host.Hostname, host.Code, host.Message)
 		}
 	}
 

--- a/cmd/goQuery/cmd/root.go
+++ b/cmd/goQuery/cmd/root.go
@@ -76,8 +76,7 @@ func Execute() {
 
 // globally accessible variable for other packages
 var (
-	cmdLineParams        = &query.Args{}
-	printDetailedSummary bool
+	cmdLineParams = &query.Args{}
 )
 
 func init() {
@@ -119,14 +118,6 @@ including the "time" field.
 		`Maximum number of final entries to show. Defaults to 95% of the overall
 data volume / number of packets (depending on the '-s' parameter).
 Ignored for queries including the "time" field.
-`,
-	)
-
-	// TODO: arguably a bit of a hack instead of going via the query.Args. Then again, I'm not sure
-	// if printing cosmetics should really live there
-	flags.BoolVar(&printDetailedSummary, conf.SummaryDetailed, false,
-		`Print details in the footer. This includes the full interface list upon a multi-interface
-query and the full host statuses table in case of a distributed query.
 `,
 	)
 
@@ -431,7 +422,7 @@ func entrypoint(cmd *cobra.Command, args []string) (err error) {
 		return nil
 	}
 
-	err = stmt.Print(ctx, result, results.WithDetailedSummary(printDetailedSummary))
+	err = stmt.Print(ctx, result)
 	if err != nil {
 		return fmt.Errorf("failed to print query result: %w", err)
 	}

--- a/cmd/goQuery/cmd/root.go
+++ b/cmd/goQuery/cmd/root.go
@@ -76,7 +76,8 @@ func Execute() {
 
 // globally accessible variable for other packages
 var (
-	cmdLineParams = &query.Args{}
+	cmdLineParams        = &query.Args{}
+	printDetailedSummary bool
 )
 
 func init() {
@@ -118,6 +119,14 @@ including the "time" field.
 		`Maximum number of final entries to show. Defaults to 95% of the overall
 data volume / number of packets (depending on the '-s' parameter).
 Ignored for queries including the "time" field.
+`,
+	)
+
+	// TODO: arguably a bit of a hack instead of going via the query.Args. Then again, I'm not sure
+	// if printing cosmetics should really live there
+	flags.BoolVar(&printDetailedSummary, conf.SummaryDetailed, false,
+		`Print details in the footer. This includes the full interface list upon a multi-interface
+query and the full host statuses table in case of a distributed query.
 `,
 	)
 
@@ -422,7 +431,7 @@ func entrypoint(cmd *cobra.Command, args []string) (err error) {
 		return nil
 	}
 
-	err = stmt.Print(ctx, result)
+	err = stmt.Print(ctx, result, results.WithDetailedSummary(printDetailedSummary))
 	if err != nil {
 		return fmt.Errorf("failed to print query result: %w", err)
 	}

--- a/cmd/goQuery/cmd/root.go
+++ b/cmd/goQuery/cmd/root.go
@@ -422,6 +422,19 @@ func entrypoint(cmd *cobra.Command, args []string) (err error) {
 		return nil
 	}
 
+	// when running a distributed query, host status errors should be reported
+	if len(result.HostsStatuses) > 1 {
+		logger, err := logging.New(logging.LevelInfo, logging.EncodingPlain,
+			logging.WithOutput(stmt.Output),
+		)
+		if err != nil {
+			return err
+		}
+		for _, host := range result.HostsStatuses.GetErrorStatuses() {
+			logger.Errorf("Host %s returned with status %q: %s", host.Hostname, host.Code, host.Message)
+		}
+	}
+
 	err = stmt.Print(ctx, result)
 	if err != nil {
 		return fmt.Errorf("failed to print query result: %w", err)

--- a/cmd/goQuery/pkg/conf/conf.go
+++ b/cmd/goQuery/pkg/conf/conf.go
@@ -35,9 +35,6 @@ const (
 	ResultsFormat = resultsKey + ".format"
 	ResultsLimit  = resultsKey + ".limit"
 
-	summaryKey      = resultsKey + ".summary"
-	SummaryDetailed = summaryKey + ".detailed"
-
 	// Memory
 	memoryKey     = "memory"
 	MemoryMaxPct  = memoryKey + ".max-pct"

--- a/cmd/goQuery/pkg/conf/conf.go
+++ b/cmd/goQuery/pkg/conf/conf.go
@@ -1,6 +1,6 @@
 package conf
 
-// Definnitions for command line parameters / arguments
+// Definitions for command line parameters / arguments
 const (
 	queryKey = "query"
 
@@ -34,6 +34,9 @@ const (
 	resultsKey    = "results"
 	ResultsFormat = resultsKey + ".format"
 	ResultsLimit  = resultsKey + ".limit"
+
+	summaryKey      = resultsKey + ".summary"
+	SummaryDetailed = summaryKey + ".detailed"
 
 	// Memory
 	memoryKey     = "memory"

--- a/pkg/query/dns/dns_test.go
+++ b/pkg/query/dns/dns_test.go
@@ -11,6 +11,7 @@
 package dns
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func TestLookup(t *testing.T) {
 
 	// 8.8.8.8 is google's DNS server. This lookup should yield the same
 	// result for many years.
-	ips2domains := TimedReverseLookup([]string{"8.8.8.8", "0.0.0.0"}, 2*time.Second)
+	ips2domains := TimedReverseLookup(context.Background(), []string{"8.8.8.8", "0.0.0.0"}, 2*time.Second)
 	if domain, ok := ips2domains["8.8.8.8"]; ok && domain != "dns.google." {
 		t.Fatalf("RDNS lookup yielded wrong result: %s", domain)
 	} else if !ok {
@@ -46,7 +47,7 @@ func TestTimeout(t *testing.T) {
 	t.Parallel()
 
 	t0 := time.Now()
-	_ = TimedReverseLookup([]string{"8.8.8.8", "8.8.4.4", "192.168.0.1", "10.0.0.1", "129.3.4.5"}, 1*time.Millisecond)
+	_ = TimedReverseLookup(context.Background(), []string{"8.8.8.8", "8.8.4.4", "192.168.0.1", "10.0.0.1", "129.3.4.5"}, 1*time.Millisecond)
 	t1 := time.Now()
 	if t1.Sub(t0) > 10*time.Millisecond {
 		t.Fatal("Timeout failed")

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -46,7 +46,7 @@ func (s *Statement) Print(ctx context.Context, result *results.Result, opts ...r
 		}
 
 		resolveStart := time.Now()
-		ips2domains = dns.TimedReverseLookup(ips, s.DNSResolution.Timeout)
+		ips2domains = dns.TimedReverseLookup(ctx, ips, s.DNSResolution.Timeout)
 		result.Summary.Timings.ResolutionDuration = time.Since(resolveStart)
 
 		opts = append(opts, results.WithIPDomainMapping(ips2domains, s.DNSResolution.Timeout))
@@ -99,7 +99,7 @@ func (s *Statement) Print(ctx context.Context, result *results.Result, opts ...r
 		}
 		return err
 	}
-	err = printer.Footer(result)
+	err = printer.Footer(ctx, result)
 	if err != nil {
 		if memErr != nil {
 			return memErr

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -3,7 +3,6 @@ package query
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/els0r/goProbe/pkg/query/dns"
@@ -63,8 +62,7 @@ func (s *Statement) Print(ctx context.Context, result *results.Result) error {
 		result.Summary.Totals,
 		result.Summary.Hits.Total,
 		s.DNSResolution.Timeout,
-		s.QueryType,
-		strings.Join(s.Ifaces, ","),
+		// TODO: make this a printer config
 	)
 	if err != nil {
 		return err

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -13,11 +13,6 @@ import (
 	"github.com/els0r/telemetry/tracing"
 )
 
-// log writes a json marshaled query statement to disk
-func (s *Statement) log() {
-	// TODO: use proper logger
-}
-
 // Print prints a statement to the result
 func (s *Statement) Print(ctx context.Context, result *results.Result) error {
 	ctx, span := tracing.Start(ctx, "(*Statement).Print")

--- a/pkg/results/TablePrinter.go
+++ b/pkg/results/TablePrinter.go
@@ -294,8 +294,6 @@ type basePrinter struct {
 	// needed for computing percentages
 	totals types.Counters
 
-	ifaces string
-
 	cols []OutputColumn
 }
 
@@ -308,9 +306,8 @@ func newBasePrinter(
 	attributes []types.Attribute,
 	ips2domains map[string]string,
 	totals types.Counters,
-	ifaces string,
 ) basePrinter {
-	result := basePrinter{output, sort, selector, direction, attributes, ips2domains, totals, ifaces,
+	result := basePrinter{output, sort, selector, direction, attributes, ips2domains, totals,
 		columns(selector, attributes, direction),
 	}
 
@@ -342,10 +339,8 @@ func NewTablePrinter(output io.Writer, format string,
 	totals types.Counters,
 	numFlows int,
 	resolveTimeout time.Duration,
-	_ string,
-	ifaces string,
 	detailed bool) (TablePrinter, error) {
-	b := newBasePrinter(output, sort, labelSel, direction, attributes, ips2domains, totals, ifaces)
+	b := newBasePrinter(output, sort, labelSel, direction, attributes, ips2domains, totals)
 
 	var printer TablePrinter
 	switch format {
@@ -462,7 +457,7 @@ func (c *CSVTablePrinter) Footer(result *Result) error {
 	if err := c.writer.Write([]string{"Sorting and flow direction", describe(c.sort, c.direction)}); err != nil {
 		return err
 	}
-	return c.writer.Write([]string{"Interface", strings.Join(results.Summary.Ifaces, ",")})
+	return c.writer.Write([]string{"Interface", strings.Join(result.Summary.Interfaces, ",")})
 }
 
 // Print flushes the writer and actually prints out all CSV rows contained in the table printer
@@ -697,7 +692,7 @@ func (t *TextTablePrinter) Footer(result *Result) error {
 	}
 
 	// distributed query information
-	if len(results.HostsStatuses) > 1 {
+	if len(result.HostsStatuses) > 1 {
 		fmt.Fprintf(t.footwriter, "Hosts:\t%s\n", result.HostsStatuses.Summary())
 	}
 

--- a/pkg/results/print.go
+++ b/pkg/results/print.go
@@ -1,0 +1,60 @@
+package results
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/els0r/goProbe/pkg/formatting"
+	"github.com/els0r/goProbe/pkg/types"
+)
+
+// FooterTabwriter is a specific tabwriter for the results footer
+type FooterTabwriter struct {
+	*tabwriter.Writer
+}
+
+// NewFooterTabwriter returns a new FooterTabwriter
+func NewFooterTabwriter(w io.Writer) *FooterTabwriter {
+	return &FooterTabwriter{
+		tabwriter.NewWriter(w, 0, 4, 1, ' ', 0),
+	}
+}
+
+// WriteEntry writes a new entry to the footer
+func (fw *FooterTabwriter) WriteEntry(key, msg string, args ...any) error {
+	_, err := fmt.Fprintf(fw.Writer, key+"\t: "+msg+"\n", args...)
+	return err
+}
+
+// Flush flushes the footer writer
+func (fw *FooterTabwriter) Flush() error {
+	return fw.Writer.Flush()
+}
+
+// FooterPrinter allows a type to print to the Footer
+type FooterPrinter interface {
+	PrintFooter(fw *FooterTabwriter) error
+}
+
+/// FooterPrinter implementations
+
+func (tr TimeRange) PrintFooter(fw *FooterTabwriter) error {
+	return fw.WriteEntry("Timespan", "[%s, %s] (%s)",
+		tr.First.Format(types.DefaultTimeOutputFormat),
+		tr.Last.Format(types.DefaultTimeOutputFormat),
+		formatting.Durationable(tr.Last.Sub(tr.First).Round(time.Minute)),
+	)
+}
+
+func (q Query) PrintFooter(fw *FooterTabwriter) error {
+	if q.Condition == "" {
+		return nil
+	}
+	return fw.WriteEntry("Conditions", q.Condition)
+}
+
+func (hs HostsStatuses) PrintFooter(fw *FooterTabwriter) error {
+	return fw.WriteEntry("Hosts", hs.Summary())
+}

--- a/pkg/results/print.go
+++ b/pkg/results/print.go
@@ -40,6 +40,7 @@ type FooterPrinter interface {
 
 /// FooterPrinter implementations
 
+// PrintFooter prints the timespan and duration covered
 func (tr TimeRange) PrintFooter(fw *FooterTabwriter) error {
 	return fw.WriteEntry("Timespan", "[%s, %s] (%s)",
 		tr.First.Format(types.DefaultTimeOutputFormat),
@@ -48,6 +49,7 @@ func (tr TimeRange) PrintFooter(fw *FooterTabwriter) error {
 	)
 }
 
+// PrintFooter prints the conditions of the query in case they are available
 func (q Query) PrintFooter(fw *FooterTabwriter) error {
 	if q.Condition == "" {
 		return nil
@@ -55,6 +57,7 @@ func (q Query) PrintFooter(fw *FooterTabwriter) error {
 	return fw.WriteEntry("Conditions", q.Condition)
 }
 
+// PrintFooter prints the queried hosts summary (total, ok, empty, error)
 func (hs HostsStatuses) PrintFooter(fw *FooterTabwriter) error {
 	return fw.WriteEntry("Hosts", hs.Summary())
 }

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -218,7 +218,7 @@ func (hs HostsStatuses) Summary() string {
 			withError++
 		}
 	}
-	return fmt.Sprintf("%d total: %d ok / %d empty / %d error", len(hs), ok, empty, withError)
+	return fmt.Sprintf("%d hosts: %d ok / %d empty / %d error", len(hs), ok, empty, withError)
 }
 
 // HostStatus bundles the Hostname with the Status for that Hostname

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -176,8 +176,8 @@ func (r *Result) End() {
 }
 
 // Summary returns a summary of the interfaces without listing them explicitly
-func (is Interface) Summary() string {
-	return fmt.Sprintr("%d", len(is))
+func (is Interfaces) Summary() string {
+	return fmt.Sprintf("%d", len(is))
 }
 
 // Print prints the sorted interface list in a table with numbered rows
@@ -208,7 +208,7 @@ type HostsStatuses map[string]Status
 // Summary returns a summary of the host statuses without going through the individual statuses
 func (hs HostsStatuses) Summary() string {
 	var ok, empty, withError int
-	for host, status := range hs {
+	for _, status := range hs {
 		switch status.Code {
 		case types.StatusOK:
 			ok++
@@ -228,7 +228,6 @@ func (hs HostsStatuses) Print(w io.Writer) error {
 		Status
 	}
 
-	var ok, empty, withError int
 	for host, status := range hs {
 		hosts = append(hosts, struct {
 			host string


### PR DESCRIPTION
### Synopsis

Separates console printing into the following stages (where `[ ]` denotes optional):

* [ error logging for failed hosts in distributed query ]
* query output (the flow table)
* summary

The summary in its longest form (e.g. a distributed query with a reverse DNS lookup and a tracing infrastructure in place) will look like:

```
Timespan           : [2024-04-15 20:44:35, 2024-04-15 21:46:37] (1h2m0s)
Interfaces / Hosts : 280 queried on 248 hosts: 114 ok / 0 empty / 134 error
Sorted by          : accumulated data volume (sent and received)
Query stats        : displayed top 25 hits out of 827 in 13.32s
Conditions         : dport = 443
Trace ID           : cff4115b6080bce9c0c233b560acd71e
```

### Changes

* Interface names are only printed if the query attribute doesn't include the interface
* removes the reverse DNS stats. The information can be extracted from a span in case a tracing infrastructure is available

### Additions

* the host statuses are summarized under the `Hosts` key
* the `Trace ID` is included if it is available to allow callers of a distributed query to inspect / debug the call across the infrastructure

Closes #301 

