### PR TITLE
[bugfix] Remove default 30 second timeout in client

### DIFF
--- a/cmd/goQuery/cmd/root.go
+++ b/cmd/goQuery/cmd/root.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/els0r/goProbe/cmd/goQuery/pkg/conf"
-	"github.com/els0r/goProbe/pkg/api/globalquery/client"
+	gqclient "github.com/els0r/goProbe/pkg/api/globalquery/client"
 	"github.com/els0r/goProbe/pkg/defaults"
 	"github.com/els0r/goProbe/pkg/goDB/engine"
 	"github.com/els0r/goProbe/pkg/query"
@@ -311,8 +311,6 @@ func entrypoint(cmd *cobra.Command, args []string) (err error) {
 		ctx = queryCtx
 	}
 
-	logger = logging.FromContext(ctx)
-
 	queryArgs.Caller = os.Args[0] // take the full path of called binary
 
 	// run the query
@@ -341,7 +339,7 @@ func entrypoint(cmd *cobra.Command, args []string) (err error) {
 		}
 
 		// query using query server
-		querier = client.New(viper.GetString(conf.QueryServerAddr))
+		querier = gqclient.New(viper.GetString(conf.QueryServerAddr))
 	} else {
 		// query using local goDB
 		querier = engine.NewQueryRunner(dbPathCfg)

--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -83,8 +83,7 @@ func WithName(name string) Option {
 }
 
 const (
-	defaultRequestTimeout = 30 * time.Second
-	defaultClientName     = "default-client"
+	defaultClientName = "default-client"
 
 	unixIdent = "unix"
 )
@@ -95,7 +94,6 @@ func NewDefault(addr string, opts ...Option) *DefaultClient {
 		client:   http.DefaultClient,
 		scheme:   "http://",
 		hostAddr: addr,
-		timeout:  defaultRequestTimeout,
 		name:     defaultClientName,
 		retry:    true,
 		retryIntervals: httpc.Intervals{

--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -83,7 +83,10 @@ func WithName(name string) Option {
 }
 
 const (
-	defaultClientName = "default-client"
+	// large request timeout to prevent unbounded request times. In practice, there will
+	// likely be a request cancellation way before this timeout is hit
+	defaultRequestTimeout = 30 * time.Minute
+	defaultClientName     = "default-client"
 
 	unixIdent = "unix"
 )
@@ -92,7 +95,6 @@ const (
 func NewDefault(addr string, opts ...Option) *DefaultClient {
 	c := &DefaultClient{
 		client:   http.DefaultClient,
-		scheme:   "http://",
 		hostAddr: addr,
 		name:     defaultClientName,
 		retry:    true,
@@ -100,6 +102,8 @@ func NewDefault(addr string, opts ...Option) *DefaultClient {
 			// retry three times before giving up
 			1 * time.Second, 2 * time.Second, 4 * time.Second,
 		},
+		scheme:  "http://",
+		timeout: defaultRequestTimeout,
 	}
 	for _, opt := range opts {
 		opt(c)


### PR DESCRIPTION
Guards against situations where `goQuery`'s `--query.timeout` parameter is ignored for global queries. It sets the default timeout to 30 minutes to provide some guardrail against long-running requests.

Closes #305 