### PR TITLE
[feature] Keep Alive for goQuery: log progress during query execution

### DIFF
--- a/cmd/goQuery/pkg/conf/conf.go
+++ b/cmd/goQuery/pkg/conf/conf.go
@@ -9,6 +9,7 @@ const (
 	QueryTimeout         = queryKey + ".timeout"
 	QueryHostsResolution = queryKey + ".hosts-resolution"
 	QueryLog             = queryKey + ".log"
+	QueryKeepAlive       = queryKey + ".keepalive"
 
 	dbKey       = "db"
 	QueryDBPath = dbKey + ".path"

--- a/pkg/goDB/DBWorkManager.go
+++ b/pkg/goDB/DBWorkManager.go
@@ -126,11 +126,11 @@ type WorkloadStats struct {
 	sync.RWMutex
 
 	BytesLoaded          uint64 `json:"bytes_loaded" doc:"Bytes loaded from disk"`
-	BytesDecompressed    uint64 `json:"bytes_decompressed,omitempty" doc:"Effective block size after decompression"`
-	BlocksProcessed      uint64 `json:"blocks_processed,omitempty" doc:"Number of blocks loaded from disk"`
-	BlocksCorrupted      uint64 `json:"blocks_corrupted,omitempty" doc:"Blocks which could not be loaded or processed"`
-	DirectoriesProcessed uint64 `json:"directories_processed,omitempty" doc:"Number of directories processed"`
-	Workloads            uint64 `json:"workloads,omitempty" doc:"Total number of workloads to be processed"`
+	BytesDecompressed    uint64 `json:"bytes_decompressed" doc:"Effective block size after decompression"`
+	BlocksProcessed      uint64 `json:"blocks_processed" doc:"Number of blocks loaded from disk"`
+	BlocksCorrupted      uint64 `json:"blocks_corrupted" doc:"Blocks which could not be loaded or processed"`
+	DirectoriesProcessed uint64 `json:"directories_processed" doc:"Number of directories processed"`
+	Workloads            uint64 `json:"workloads" doc:"Total number of workloads to be processed"`
 }
 
 // LogValue implements the slog.LogValuer interface

--- a/pkg/goDB/engine/aggregate.go
+++ b/pkg/goDB/engine/aggregate.go
@@ -41,8 +41,7 @@ func (i internalError) Error() string {
 // Then send aggregation result over resultChan.
 // If an error occurs, aggregate may return prematurely.
 // Closes resultChan on termination.
-func aggregate(mapChan <-chan hashmap.AggFlowMapWithMetadata, ifaces []string, isLowMem bool) chan aggregateResult {
-
+func (qr *QueryRunner) aggregate(mapChan <-chan hashmap.AggFlowMapWithMetadata, ifaces []string, isLowMem bool) chan aggregateResult {
 	// create channel that returns the final aggregate result
 	resultChan := make(chan aggregateResult, 1)
 

--- a/pkg/goDB/storage/storage.go
+++ b/pkg/goDB/storage/storage.go
@@ -6,9 +6,13 @@ import (
 
 // Block denotes a block of goprobe data
 type Block struct {
-	Offset      uint64
-	Len         uint32
-	RawLen      uint32
+	// Offset is the position within the .gpf file
+	Offset uint64
+	// Len is the length of data as it is on disk
+	Len uint32
+	// RawLen is the original (uncompressed) length of data
+	RawLen uint32
+	// EncoderType is the type of encoder which was used to compress data
 	EncoderType encoders.Type
 }
 


### PR DESCRIPTION
This commit provides a _simple_ (!) keep-alive mechanism, which can be used to inform the caller of `goQuery` that a query is still running.

The `--query.keepalive` or `-k` shorthand specifies an interval after which the caller gets a query processing update. By default, it is 0, which equates no keep alive.

### Example Output

```nothing
ts=2024-05-23T14:39:01.715Z level=info msg="processed work dir" version=devel worker.id=7 iface=eth0 dir=.db/eth0/2024/03/1710460800 stats.bytes_loaded=0 stats.bytes_decompressed=3848214 stats.blocks_processed=17860 stats.blocks_corrupted=0 stats.directories_processed=31 stats.workloads=1
ts=2024-05-23T14:39:01.931Z level=info msg="processed workload" version=devel iface=eth0 dir=.db/eth0 stats.bytes_loaded=0 stats.bytes_decompressed=7357134 stats.blocks_processed=68980 stats.blocks_corrupted=0 stats.directories_processed=60 stats.workloads=2
ts=2024-05-23T14:39:01.933Z level=info msg="processed workload" version=devel iface=eth0 dir=.db/eth0 stats.bytes_loaded=0 stats.bytes_decompressed=10069197 stats.blocks_processed=105844 stats.blocks_corrupted=0 stats.directories_processed=92 stats.workloads=3
ts=2024-05-23T14:39:01.933Z level=info msg="processed workload" version=devel iface=eth0 dir=.db/eth0 stats.bytes_loaded=0 stats.bytes_decompressed=12768653 stats.blocks_processed=142716 stats.blocks_corrupted=0 stats.directories_processed=124 stats.workloads=4
ts=2024-05-23T14:39:01.968Z level=info msg="processed workload" version=devel iface=eth0 dir=.db/eth0 stats.bytes_loaded=0 stats.bytes_decompressed=16810721 stats.blocks_processed=179588 stats.blocks_corrupted=0 stats.directories_processed=156 stats.workloads=5
ts=2024-05-23T14:39:01.969Z level=info msg="processed workload" version=devel iface=eth0 dir=.db/eth0 stats.bytes_loaded=0 stats.bytes_decompressed=19428092 stats.blocks_processed=216456 stats.blocks_corrupted=0 stats.directories_processed=188 stats.workloads=6
ts=2024-05-23T14:39:01.970Z level=info msg="processed workload" version=devel iface=eth0 dir=.db/eth0 stats.bytes_loaded=0 stats.bytes_decompressed=22129050 stats.blocks_processed=253324 stats.blocks_corrupted=0 stats.directories_processed=220 stats.workloads=7

                           packets   packets            bytes     bytes       
         sip         dip        in       out      %        in       out      %
  200.13.1.2  200.24.1.2   41.38 M   49.49 M  25.26   5.09 GB   6.09 GB  22.47
                               ...       ...              ...       ...       
                          191.16 M  168.53 M         28.11 GB  21.62 GB       
                                                                       
     Totals:                        359.69 M                   49.73 GB  

Timespan    : [2023-09-06 23:58:54, 2024-04-13 20:35:00] (219d20h36m0s)
Interface   : eth0
Sorted by   : accumulated data volume (sent and received)
Query stats : displayed top 1 hits out of 506 in 7.448s
```

### Other Changes

The `stats` label in the log output stems from a `WorkloadStats` struct which tracks interactions with the DB engine. Mainly how much data is loaded and processed.

It is meant to be extended in future iterations.