### PR TITLE
[bugfix] Strip whitespace from `args.Query` when sanitizing it

### DIFF
--- a/cmd/global-query/pkg/distributed/query.go
+++ b/cmd/global-query/pkg/distributed/query.go
@@ -70,6 +70,9 @@ func (q *QueryRunner) Run(ctx context.Context, args *query.Args) (*results.Resul
 	ctx, span := tracing.Start(ctx, "(*distributed.QueryRunner).Run", trace.WithAttributes(attribute.String("args", queryArgs.ToJSONString())))
 	defer span.End()
 
+	// sanitize the query attributes
+	queryArgs.Query = types.SanitizeQueryType(queryArgs.Query)
+
 	// check if the statement can be created
 	stmt, err := queryArgs.Prepare()
 	if err != nil {

--- a/pkg/types/columns.go
+++ b/pkg/types/columns.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/els0r/goProbe/pkg/goDB/protocols"
 )
@@ -256,8 +257,21 @@ const (
 	RawCompoundQuery         = "raw"
 )
 
+// spaceMap removes all whitespace is the string (including \t and \n)
+func spaceMap(str string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, str)
+}
+
 // Tokenize translates query abbreviations into the attributes they hold
 func Tokenize(queryType string) (tokens []string) {
+	// trim any kind of whitespace from the query type
+	queryType = spaceMap(queryType)
+
 	// covers the case where aliases and attribute/label names are mixed (e.g. talk_conv,dport)
 	qtSplit := strings.Split(queryType, AttrSep)
 	if len(qtSplit) > 1 {

--- a/pkg/types/columns_test.go
+++ b/pkg/types/columns_test.go
@@ -11,7 +11,6 @@
 package types
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -93,6 +92,8 @@ var parseQueryTypeTests = []struct {
 	{"dst", []Attribute{DIPAttribute{}}, false, false},
 	{"talk_src", []Attribute{SIPAttribute{}}, false, false},
 	{"sip,dip,dip,sip,dport", []Attribute{SIPAttribute{}, DIPAttribute{}, DportAttribute{}}, false, false},
+	{` sip,	dip,  dip, sip,
+	dport `, []Attribute{SIPAttribute{}, DIPAttribute{}, DportAttribute{}}, false, false},
 	{"sip,dip,dip,iface,sip,dport", []Attribute{SIPAttribute{}, DIPAttribute{}, DportAttribute{}}, false, true},
 	{"sip,dip,dst,src,dport", []Attribute{SIPAttribute{}, DIPAttribute{}, DportAttribute{}}, false, false},
 	{"src,dst,dip,sip,dport", []Attribute{SIPAttribute{}, DIPAttribute{}, DportAttribute{}}, false, false},
@@ -104,9 +105,8 @@ var parseQueryTypeTests = []struct {
 }
 
 func TestParseQueryType(t *testing.T) {
-	for i, test := range parseQueryTypeTests {
-		test := test
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+	for _, test := range parseQueryTypeTests {
+		t.Run(test.InQueryType, func(t *testing.T) {
 			attributes, selector, err := ParseQueryType(test.InQueryType)
 			require.Nilf(t, err, "Unexpectedly failed on input %v", test.InQueryType)
 			require.Equal(t, test.OutHasAttrIface, selector.Iface)


### PR DESCRIPTION
This fixes a bug where queries such as `"sip, dip,dport"` wouldn't be evaluated only because of the whitespace in them.

The implicit assumption was that this wouldn't happen if called from the command line (due to the arguments being evaluated as `[]string{..., "sip,", "dip,dport"}`. For the `json` case, this is very much a valid way of passing the arguments.

Sanitization is applied both in goQuery (to local DB) and global-query.

Closes #347 .