### PR TITLE
[bugfix] Improve keepalive signal for queries

### DIFF
--- a/pkg/goDB/DBWorkManager.go
+++ b/pkg/goDB/DBWorkManager.go
@@ -49,8 +49,6 @@ const (
 
 	// defaultEncoderType denotes the default encoder / compressor
 	defaultEncoderType = encoders.EncoderTypeLZ4
-
-	keepAliveInterval = 5 * time.Second
 )
 
 // DBWorkManager schedules parallel processing of blocks relevant for a query
@@ -669,6 +667,9 @@ func (w *DBWorkManager) readBlocksAndEvaluate(workDir *gpfile.GPDir, enc encoder
 				}
 			}
 		}
+
+		// Update keepalive (if required)
+		w.query.UpdateKeepalive()
 
 		// In case any error was observed during above sanity checks, skip this whole block
 		if blockBroken {

--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -354,8 +354,9 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement) 
 			count++
 		}
 
-		// add statistics to final result
+		// add statistics to final result and trigger keepalive (if required)
 		result.Summary.Stats.Add(aggMap.Stats)
+		qr.query.UpdateKeepalive()
 
 		// Now is a good time to release memory one last time for the final processing step
 		if qr.query.IsLowMem() {

--- a/pkg/types/workload/stats.go
+++ b/pkg/types/workload/stats.go
@@ -74,8 +74,9 @@ type Stats struct {
 }
 
 // LogValue implements the slog.LogValuer interface
-func (s *Stats) LogValue() slog.Value {
-	return slog.GroupValue(
+func (s *Stats) LogValue() (v slog.Value) {
+	s.RLock()
+	v = slog.GroupValue(
 		slog.Uint64("bytes_loaded", s.BytesLoaded),
 		slog.Uint64("bytes_decompressed", s.BytesDecompressed),
 		slog.Uint64("blocks_processed", s.BlocksProcessed),
@@ -83,6 +84,8 @@ func (s *Stats) LogValue() slog.Value {
 		slog.Uint64("directories_processed", s.DirectoriesProcessed),
 		slog.Uint64("workloads", s.Workloads),
 	)
+	s.RUnlock()
+	return
 }
 
 // Add adds the values of stats to s
@@ -90,10 +93,12 @@ func (s *Stats) Add(stats *Stats) {
 	if stats == nil {
 		return
 	}
+	s.Lock()
 	s.BlocksProcessed += stats.BlocksProcessed
 	s.BytesDecompressed += stats.BytesDecompressed
 	s.BlocksProcessed += stats.BlocksProcessed
 	s.BlocksCorrupted += stats.BlocksCorrupted
 	s.DirectoriesProcessed += stats.DirectoriesProcessed
 	s.Workloads += stats.Workloads
+	s.Unlock()
 }


### PR DESCRIPTION
Addresses the following:

- Disentangles the keepalive from the aggregation step (which may just receive new maps / workloads at a too slow rate to ensure sufficient keepalive frequency)
- Cleanup interaction by moving keepalive tracking into the query
- Remove `iface` from keepalive signal (i.e. log line) since it is / was pointless anyway (as it depends solely on which map was being processed at the time of the signa and hence is totally random)

Closes #350 