### PR TITLE
[bugfix] Ensure that no live queries can be performed against a local DB

### DIFF
--- a/cmd/goQuery/cmd/root.go
+++ b/cmd/goQuery/cmd/root.go
@@ -374,6 +374,9 @@ func entrypoint(cmd *cobra.Command, args []string) (err error) {
 			querier = gqclient.New(viper.GetString(conf.QueryServerAddr))
 		}
 	} else {
+		if queryArgs.Live {
+			return errors.New("cannot run live query in local DB mode")
+		}
 		// query using local goDB
 		querier = engine.NewQueryRunner(dbPathCfg, engine.WithKeepAlive(viper.GetDuration(conf.QueryKeepAlive)))
 	}

--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -22,6 +22,7 @@ import (
 	"github.com/els0r/goProbe/pkg/types"
 	"github.com/els0r/goProbe/pkg/types/hashmap"
 	"github.com/els0r/goProbe/pkg/types/workload"
+	"github.com/els0r/telemetry/logging"
 	"github.com/els0r/telemetry/tracing"
 	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/otel/attribute"
@@ -396,6 +397,12 @@ func (qr *QueryRunner) runLiveQuery(ctx context.Context, mapChan chan hashmap.Ag
 	wg = new(sync.WaitGroup)
 
 	if !stmt.Live {
+		return
+	}
+	// If for some reason a live query was attempted without a CaptureManager running,
+	// throw an error and bail
+	if qr.captureManager == nil {
+		logging.FromContext(ctx).Error("no CaptureManager available, cannot run live query")
 		return
 	}
 

--- a/pkg/query/args.go
+++ b/pkg/query/args.go
@@ -486,7 +486,6 @@ func (a *Args) Prepare(writers ...io.Writer) (*Statement, error) {
 
 	// check for consistent use of the live flag
 	if s.Live && s.Last != types.MaxTime.Unix() {
-		// collect error
 		errModel.Errors = append(errModel.Errors, &huma.ErrorDetail{
 			Message:  fmt.Sprintf("%s: last timestamp unsupported", invalidLiveQueryMsg),
 			Location: "live",


### PR DESCRIPTION
Turns out not _everything_ is validated when reading a serialized query from disk / JSON. In particular, there is no check if said query attempts to perform a live query against a local DB instead of an API (which caused the panic due a missing `CaptureManager`). This is now caught in two places (firstly preventing such queries to run in the first place and secondly gracefully skipping the query with an error message should it happen anyway).