### PR TITLE
[trivial] Bump dev image version to 1.23

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,5 @@ RUN mkdir -p /var/lib/dbus/ && echo "da314207b73d8b1bdeb86e5adfa0d6cb" > /var/li
 
 # go
 USER vscode
-RUN go clean -modcache
 RUN go install golang.org/x/tools/gopls@latest
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.22-bullseye
+FROM mcr.microsoft.com/devcontainers/go:1.23-bullseye
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install git \
@@ -16,5 +16,6 @@ RUN mkdir -p /var/lib/dbus/ && echo "da314207b73d8b1bdeb86e5adfa0d6cb" > /var/li
 
 # go
 USER vscode
+RUN go clean -modcache
 RUN go install golang.org/x/tools/gopls@latest
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2


### PR DESCRIPTION
 'RUN go install golang.org/x/tools/gopls@latest' fails due to latest gopls requiring 1.23 or higher