### PR TITLE
[feature] Simplify slide exporting feature and provide PDF

### DIFF
--- a/presentations/2025/goprobe_bern_meetup/Makefile
+++ b/presentations/2025/goprobe_bern_meetup/Makefile
@@ -3,3 +3,6 @@ deps:
 
 run:
 	npm exec -c 'slidev "slides.md" --port 3031'
+
+export:
+	npm exec -c 'slidev export --with-clicks'

--- a/presentations/2025/goprobe_bern_meetup/package.json
+++ b/presentations/2025/goprobe_bern_meetup/package.json
@@ -37,7 +37,9 @@
     "@slidev/types": "^51.1.1",
     "@vueuse/core": "^12.7.0",
     "@vueuse/math": "^12.7.0",
+    "codemirror-theme-vars": "^0.1.2",
     "defu": "^6.1.4",
+    "prism-theme-vars": "^0.2.5",
     "slidev-theme-eloc": "^1.1.0"
   },
   "devDependencies": {

--- a/presentations/2025/goprobe_bern_meetup/slides.md
+++ b/presentations/2025/goprobe_bern_meetup/slides.md
@@ -4,6 +4,7 @@ theme: ./theme
 layout: intro-image
 image: ./pictures/bg-initial.png
 title: Global Network Observability with goProbe
+exportFilename: global-network-observability-with-goprobe
 ---
 
 <style>


### PR DESCRIPTION
Adds some convenience stuff for PDF rendering (the browser exporter is buggy, so use the CLI via `Makefile`) and provide PDF version of Bern Go Meetup 2025 slides.