### PR TITLE
[bugfix] Print table footer on console even if no data was found

### DIFF
--- a/cmd/goQuery/cmd/root.go
+++ b/cmd/goQuery/cmd/root.go
@@ -458,7 +458,6 @@ func entrypoint(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 		logger.Infof("Status %q: %s", result.Status.Code, result.Status.Message)
-		return nil
 	}
 
 	// when running a distributed query, host status errors should be reported

--- a/pkg/goDB/engine/query.go
+++ b/pkg/goDB/engine/query.go
@@ -268,15 +268,18 @@ func (qr *QueryRunner) RunStatement(ctx context.Context, stmt *query.Statement, 
 		}
 	}
 
-	// the covered time period is the union of all covered times
-	tSpanFirst, tSpanLast := time.Now().AddDate(100, 0, 0), time.Time{} // a hundred years in the future, the beginning of time
-	for _, workManager := range workManagers {
-		t0, t1 := workManager.GetCoveredTimeInterval()
-		if t0.Before(tSpanFirst) {
-			tSpanFirst = t0
-		}
-		if tSpanLast.Before(t1) {
-			tSpanLast = t1
+	// the covered time period is the union of all covered times (initialize to query time period in case no work managers are created
+	tSpanFirst, tSpanLast := time.Unix(stmt.First, 0), time.Unix(stmt.Last, 0)
+	if len(workManagers) > 0 {
+		tSpanFirst, tSpanLast = time.Now().AddDate(100, 0, 0), time.Time{} // a hundred years in the future, the beginning of time
+		for _, workManager := range workManagers {
+			t0, t1 := workManager.GetCoveredTimeInterval()
+			if t0.Before(tSpanFirst) {
+				tSpanFirst = t0
+			}
+			if tSpanLast.Before(t1) {
+				tSpanLast = t1
+			}
 		}
 	}
 


### PR DESCRIPTION
Instead of breaking out of the table processing if no data was found the table will now still be printed, but the rows and their headers are simply omitted if no rows were received, leading to a footer-only output:
```
└─ $ ▶ ./goQuery   -d /home/fako/Downloads/db -f -1d -n 10 -i any sip,dip
Status "missing_data": no data available for the specified interface(s) / time range (maybe goProbe was not running)

Timespan    : [2025-04-25 11:31:49, 2025-04-26 11:31:49] (1d0s)
Interface   : 23 queried
Sorted by   : accumulated data volume (sent and received)
Query stats : displayed top 0 hits out of 0 in 2ms
```

Side-note: At some point we should refactor the whole printer concept, it's a bit contrived (also has several fundamental code issues caught by today's linter configs).

Closes #360 