### PR TITLE
[bugfix] Make sure that partial results also include rows

### DIFF
--- a/cmd/global-query/pkg/distributed/query.go
+++ b/cmd/global-query/pkg/distributed/query.go
@@ -1,3 +1,4 @@
+// Package distributed handles distributed queries across multiple hosts
 package distributed
 
 import (
@@ -309,6 +310,6 @@ func finalizeResult(res *results.Result, stmt *query.Statement, rowMap results.R
 
 	// truncate by limit
 	if limit < uint64(len(res.Rows)) {
-		res.Rows = res.Rows[:stmt.NumResults]
+		res.Rows = res.Rows[:limit]
 	}
 }

--- a/cmd/global-query/pkg/distributed/query_test.go
+++ b/cmd/global-query/pkg/distributed/query_test.go
@@ -1,0 +1,288 @@
+package distributed
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2/sse"
+	"github.com/els0r/goProbe/v4/pkg/api"
+	"github.com/els0r/goProbe/v4/pkg/distributed/hosts"
+	"github.com/els0r/goProbe/v4/pkg/query"
+	"github.com/els0r/goProbe/v4/pkg/results"
+	"github.com/els0r/goProbe/v4/pkg/types"
+	"github.com/els0r/goProbe/v4/plugins/resolver/stringresolver"
+	"github.com/stretchr/testify/require"
+)
+
+// mockResolver is a simple Resolver that records calls and returns a preset list
+type mockResolver struct {
+	calledWith string
+	calls      int
+	out        hosts.Hosts
+	err        error
+}
+
+func (m *mockResolver) Resolve(_ context.Context, query string) (hosts.Hosts, error) {
+	m.calls++
+	m.calledWith = query
+	return m.out, m.err
+}
+
+// mockQuerier implements distributed.Querier and optionally distributed.QuerierAnyable
+type mockQuerier struct {
+	lastCtx   context.Context
+	lastHosts hosts.Hosts
+	lastArgs  *query.Args
+	results   []*results.Result
+	anyHosts  hosts.Hosts
+}
+
+func (m *mockQuerier) Query(ctx context.Context, queryHosts hosts.Hosts, args *query.Args) (<-chan *results.Result, <-chan struct{}) {
+	m.lastCtx = ctx
+	m.lastHosts = queryHosts
+	m.lastArgs = args
+	rc := make(chan *results.Result, len(m.results))
+	kc := make(chan struct{})
+	for _, r := range m.results {
+		rc <- r
+	}
+	close(rc)
+	close(kc)
+	return rc, kc
+}
+
+func (m *mockQuerier) AllHosts() (hosts.Hosts, error) { // implements distributed.QuerierAnyable
+	return m.anyHosts, nil
+}
+
+func makeResult(host, iface string, bytes, packets uint64) *results.Result {
+	r := results.New()
+	r.Start()
+	r.Hostname = host
+	r.Rows = results.Rows{
+		{
+			Labels:     results.Labels{Iface: iface, Hostname: host},
+			Attributes: results.Attributes{DstPort: 80},
+			Counters:   types.Counters{BytesRcvd: bytes, PacketsRcvd: packets},
+		},
+	}
+	r.Summary.Interfaces = []string{iface}
+	r.Summary.First = time.Now().Add(-time.Hour)
+	r.Summary.Last = time.Now()
+	r.Summary.Hits.Total = len(r.Rows)
+	return r
+}
+
+func baseArgs() *query.Args {
+	return &query.Args{
+		Query:      "sip",
+		Ifaces:     "eth0",
+		Format:     "json",
+		MaxMemPct:  60,
+		NumResults: 100,
+		First:      time.Now().Add(-time.Hour).Format(time.RFC3339),
+		Last:       time.Now().Format(time.RFC3339),
+	}
+}
+
+func TestRun_ErrorWhenQueryHostsEmpty(t *testing.T) {
+	mr := &mockResolver{}
+	mq := &mockQuerier{}
+	qr := NewQueryRunner(mr, mq)
+
+	args := baseArgs()
+	args.QueryHosts = ""
+
+	res, err := qr.Run(context.Background(), args)
+	require.Nil(t, res)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "query for target hosts is empty")
+	require.Equal(t, 0, mr.calls)
+}
+
+func TestRun_UsesResolverAndAggregatesResults(t *testing.T) {
+	mr := &mockResolver{out: hosts.Hosts{"h1", "h2"}}
+	mq := &mockQuerier{results: []*results.Result{
+		makeResult("h1", "eth0", 10, 1),
+		makeResult("h2", "eth0", 20, 2),
+	}}
+	qr := NewQueryRunner(mr, mq)
+
+	args := baseArgs()
+	args.QueryHosts = "h1,h2"
+
+	res, err := qr.Run(context.Background(), args)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// Resolver was used
+	require.Equal(t, 1, mr.calls)
+	require.Equal(t, "h1,h2", mr.calledWith)
+	require.ElementsMatch(t, mr.out, mq.lastHosts)
+
+	// Aggregation combined rows and interfaces, and totals reflect both inputs
+	require.Equal(t, 2, res.Summary.Hits.Total)
+	require.Len(t, res.Rows, 2)
+	require.ElementsMatch(t, []string{"eth0"}, res.Summary.Interfaces)
+}
+
+func TestRun_AnySelector_UsesQuerierAnyable(t *testing.T) {
+	mr := &mockResolver{out: hosts.Hosts{"should-not-be-used"}}
+	mq := &mockQuerier{anyHosts: hosts.Hosts{"any1", "any2"}, results: []*results.Result{
+		makeResult("any1", "eth0", 5, 1),
+		makeResult("any2", "eth0", 7, 1),
+	}}
+	qr := NewQueryRunner(mr, mq)
+
+	args := baseArgs()
+	args.QueryHosts = types.AnySelector
+
+	res, err := qr.Run(context.Background(), args)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// Resolver should not have been called
+	require.Equal(t, 0, mr.calls)
+	require.ElementsMatch(t, mq.anyHosts, mq.lastHosts)
+}
+
+func TestRun_StringResolverOverride(t *testing.T) {
+	// panicResolver ensures QueryRunner uses the string resolver override
+	panicResolver := &mockResolver{out: nil}
+	mq := &mockQuerier{results: []*results.Result{makeResult("a", "eth0", 1, 1)}}
+	qr := NewQueryRunner(panicResolver, mq)
+
+	args := baseArgs()
+	args.QueryHosts = "b, a, a"
+	args.QueryHostsResolverType = stringresolver.Type
+
+	res, err := qr.Run(context.Background(), args)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// The used hosts should be sorted & de-duplicated by string resolver
+	require.ElementsMatch(t, hosts.Hosts{"a", "b"}, mq.lastHosts)
+	// Original resolver should not be called
+	require.Equal(t, 0, panicResolver.calls)
+}
+
+// captureSender captures SSE messages via the Sender function
+type captureSender struct {
+	mu     sync.Mutex
+	events []struct {
+		kind string
+		rows int
+	}
+}
+
+func (c *captureSender) send(msg sse.Message) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch v := msg.Data.(type) {
+	case *api.PartialResult:
+		c.events = append(c.events, struct {
+			kind string
+			rows int
+		}{kind: "partial", rows: len(v.Rows)})
+	case *api.Keepalive:
+		c.events = append(c.events, struct {
+			kind string
+			rows int
+		}{kind: "keepalive", rows: 0})
+	}
+	return nil
+}
+
+// scriptedQuerier lets tests control result and keepalive emissions
+type scriptedQuerier struct {
+	rc chan *results.Result
+	kc chan struct{}
+}
+
+func (sq *scriptedQuerier) Query(_ context.Context, _ hosts.Hosts, _ *query.Args) (<-chan *results.Result, <-chan struct{}) {
+	return sq.rc, sq.kc
+}
+
+func TestRunStreaming_PartialResults_IncludeRows(t *testing.T) {
+	// Arrange
+	mr := &mockResolver{out: hosts.Hosts{"h1", "h2"}}
+	sq := &scriptedQuerier{rc: make(chan *results.Result, 2), kc: make(chan struct{}, 1)}
+	qr := NewQueryRunner(mr, sq)
+
+	args := baseArgs()
+	args.QueryHosts = "h1,h2"
+
+	sender := &captureSender{}
+
+	// Act: send two per-host results, then close
+	sq.rc <- makeResult("h1", "eth0", 10, 1)
+	sq.rc <- makeResult("h2", "eth0", 20, 2)
+	close(sq.rc)
+	close(sq.kc)
+
+	res, err := qr.RunStreaming(context.Background(), args, sse.Sender(sender.send))
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// Expect two PartialResult SSE events with increasing row counts
+	var rowCounts []int
+	for _, ev := range sender.events {
+		if ev.kind == "partial" {
+			rowCounts = append(rowCounts, ev.rows)
+		}
+	}
+	require.Len(t, rowCounts, 2)
+	require.Equal(t, 1, rowCounts[0])
+	require.Equal(t, 2, rowCounts[1])
+}
+
+func TestRunStreaming_Keepalives_AreEmitted(t *testing.T) {
+	// Arrange
+	mr := &mockResolver{out: hosts.Hosts{"h1"}}
+	// unbuffered result channel to keep aggregation running while we emit keepalives
+	rc := make(chan *results.Result)
+	kc := make(chan struct{}, 8)
+	sq := &scriptedQuerier{rc: rc, kc: kc}
+	qr := NewQueryRunner(mr, sq)
+
+	args := baseArgs()
+	args.QueryHosts = "h1"
+	args.KeepAlive = 5 * time.Millisecond
+
+	sender := &captureSender{}
+
+	// Emit keepalives with spacing > keepalive interval to trigger sends,
+	// then send a result and close channels to finish.
+	go func() {
+		// allow forwardKeepalives goroutine to start
+		time.Sleep(2 * time.Millisecond)
+		kc <- struct{}{}
+		time.Sleep(12 * time.Millisecond)
+		kc <- struct{}{}
+		time.Sleep(12 * time.Millisecond)
+		kc <- struct{}{}
+		close(kc)
+		// now allow aggregation to complete
+		rc <- makeResult("h1", "eth0", 1, 1)
+		close(rc)
+	}()
+
+	res, err := qr.RunStreaming(context.Background(), args, sse.Sender(sender.send))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// Assert at least one keepalive event was emitted.
+	// Note: exact counts are timing-sensitive and can be flaky across environments,
+	// so we only verify presence rather than a specific minimum beyond 1.
+	keepaliveCount := 0
+	for _, ev := range sender.events {
+		if ev.kind == "keepalive" {
+			keepaliveCount++
+		}
+	}
+	require.GreaterOrEqual(t, keepaliveCount, 1, sender.events)
+}

--- a/pkg/api/globalquery/server/server.go
+++ b/pkg/api/globalquery/server/server.go
@@ -1,3 +1,4 @@
+// Package server provides the API server implementation for the global-query service
 package server
 
 import (

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -1,3 +1,4 @@
+// Package api provides the API definitions and handlers for the query service
 package api
 
 import (

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -28,7 +28,7 @@ func OnResult(res *results.Result, send sse.Sender) error {
 	return send.Data(&PartialResult{res})
 }
 
-// OnResultFn is a generic handler / function that sends a keepalive signal via an SSE sender
+// OnKeepalive is a generic handler / function that sends a keepalive signal via an SSE sender
 // to the client(s)
 func OnKeepalive(send sse.Sender) error {
 	return send.Data(&Keepalive{})

--- a/pkg/api/query_api_ops.go
+++ b/pkg/api/query_api_ops.go
@@ -120,7 +120,11 @@ func registerDistributedQueryAPI(a huma.API, caller string, qr SSEQueryRunner, m
 			Method:      http.MethodPost,
 			Path:        SSEQueryRoute,
 			Summary:     "Run query with server sent events (SSE)",
-			Description: "Runs a query based on the parameters provided in the body. Pushes back partial results via SSE",
+			Description: `Runs a query based on the parameters provided in the body.
+
+Pushes back partial results via SSE. Partial results will be truncated to the first 100 items to save bandwidth on larger queries.
+
+The final result will honor the limit parameter passed in the query args.`,
 			Middlewares: middlewares,
 			Tags:        queryTags,
 		},

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -184,20 +184,22 @@ func (r *Result) Start() {
 // End prepares the end of the result
 func (r *Result) End() {
 	r.Summary.Timings.QueryDuration = time.Since(r.Summary.Timings.QueryStart)
-	if len(r.Rows) == 0 {
-		if r.Summary.DataAvailable {
-			r.Status = Status{
-				Code:    types.StatusEmpty,
-				Message: ErrorNoResults.Error(),
-			}
-		} else {
-			r.Status = Status{
-				Code:    types.StatusMissingData,
-				Message: ErrorDataMissing.Error(),
-			}
-		}
-	}
+	r.Summary.Hits.Displayed = len(r.Rows)
 	sort.Strings(r.Summary.Interfaces)
+	if len(r.Rows) != 0 {
+		return
+	}
+	if r.Summary.DataAvailable {
+		r.Status = Status{
+			Code:    types.StatusEmpty,
+			Message: ErrorNoResults.Error(),
+		}
+		return
+	}
+	r.Status = Status{
+		Code:    types.StatusMissingData,
+		Message: ErrorDataMissing.Error(),
+	}
 }
 
 // Summary returns a summary of the interfaces without listing them explicitly

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -63,7 +63,7 @@ type Status string
 const (
 	StatusError           Status = "error"
 	StatusEmpty           Status = "empty"
-	StatusMissingData     Status = "missing_data"
+	StatusMissingData     Status = "missing data"
 	StatusTooManyRequests Status = "too many requests"
 	StatusOK              Status = "ok"
 )

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,3 +1,4 @@
+// Package types provides the common types and utilities for querying data
 package types
 
 import (


### PR DESCRIPTION
Addresses a bug where `rows` were `null` if part of a `partialResult` in an event stream.

The amount of rows are guarded by the `limit` parameter, as well as a maximum of 100 rows per partial result. This is to save bandwidth when streaming results for queries having a large limit set.

The logic for producing the final result is now consolidated and shared between the `sse.Send` part of the query code and the finalization code. All results manipulation happens inside `run` now.

Finally, the `distributed` package adds tests to verify basic behavior as well as the above for SSE sends.

Closes #401 .