### PR TITLE
[feature] Provide access to all configured resolver plugins

### DIFF
--- a/cmd/global-query/cmd/help.go
+++ b/cmd/global-query/cmd/help.go
@@ -1,13 +1,10 @@
 package cmd
 
-var supportedCmds = "{server}"
-
-var helpBase = `
+const (
+	supportedCmds = "{server}"
+	helpBase      = `
   global-query ` + supportedCmds + `
 
   Query server for running distributed goQuery queries and aggregating the results.
 `
-
-var helpBaseLong = helpBase + `
-  Meant to run in server mode via the "server" command.
-`
+)

--- a/cmd/global-query/cmd/init_plugins.go
+++ b/cmd/global-query/cmd/init_plugins.go
@@ -13,6 +13,7 @@ import (
 	// internal plugin support
 	_ "github.com/els0r/goProbe/v4/plugins/querier"
 	_ "github.com/els0r/goProbe/v4/plugins/resolver"
+	"github.com/els0r/goProbe/v4/plugins/resolver/stringresolver"
 )
 
 func initQuerier(ctx context.Context) (querier distributed.Querier, err error) {
@@ -22,9 +23,22 @@ func initQuerier(ctx context.Context) (querier distributed.Querier, err error) {
 	)
 }
 
-func initResolver(ctx context.Context) (resolver hosts.Resolver, err error) {
-	return plugins.InitResolver(ctx,
-		viper.GetString(conf.HostsResolverType),
-		viper.GetString(conf.HostsResolverConfig),
-	)
+func initResolvers(ctx context.Context) (resolvers *hosts.ResolverMap, err error) {
+	appCfg := &plugins.AppConfig{}
+	if err := viper.Unmarshal(&appCfg); err != nil {
+		return nil, err
+	}
+
+	appCfg.Hosts.Resolvers = append(appCfg.Hosts.Resolvers,
+		// supports the flag values
+		&plugins.ResolverConfig{
+			Type:   viper.GetString(conf.HostsResolverType),
+			Config: viper.GetString(conf.HostsResolverConfig),
+		},
+		// always register the string resolver
+		&plugins.ResolverConfig{
+			Type: stringresolver.Type,
+		})
+
+	return plugins.InitResolvers(ctx, appCfg.Hosts)
 }

--- a/cmd/global-query/cmd/init_plugins_test.go
+++ b/cmd/global-query/cmd/init_plugins_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/els0r/goProbe/v4/cmd/global-query/pkg/conf"
+	"github.com/els0r/goProbe/v4/pkg/distributed/hosts"
+	"github.com/els0r/goProbe/v4/plugins/querier/apiclient"
+	"github.com/els0r/goProbe/v4/plugins/resolver/stringresolver"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitQuerier_UsesViperAndReturnsAPIClientQuerier(t *testing.T) {
+	viper.Reset()
+
+	// Prepare minimal valid API client config
+	f, err := os.CreateTemp(t.TempDir(), "api-client-*.yaml")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(f.Name()) })
+	_, err = f.WriteString("host1:\n  addr: localhost:8145\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	viper.Set(conf.QuerierType, apiclient.Name)
+	viper.Set(conf.QuerierConfig, f.Name())
+
+	q, err := initQuerier(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, q)
+	// confirm the concrete type
+	_, ok := q.(*apiclient.APIClientQuerier)
+	require.True(t, ok, "querier should be *APIClientQuerier")
+}
+
+func TestInitResolvers_AppendsFlagAndStringResolver(t *testing.T) {
+	viper.Reset()
+
+	// Ensure hosts struct exists on unmarshal; start with empty list
+	viper.Set("hosts.resolvers", []map[string]string{})
+
+	// Provide resolver via flags (type=string, config empty) and expect string resolver present
+	viper.Set(conf.HostsResolverType, stringresolver.Type)
+	viper.Set(conf.HostsResolverConfig, "")
+
+	rm, err := initResolvers(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rm)
+
+	// Should have at least the string resolver registered
+	r, ok := rm.Get(stringresolver.Type)
+	require.True(t, ok)
+	require.Implements(t, (*hosts.Resolver)(nil), r)
+}
+
+func TestInitQuerier_UnknownType_ReturnsError(t *testing.T) {
+	viper.Reset()
+	viper.Set(conf.QuerierType, "does-not-exist")
+	viper.Set(conf.QuerierConfig, "")
+
+	q, err := initQuerier(context.Background())
+	require.Error(t, err)
+	require.Nil(t, q)
+}

--- a/cmd/global-query/cmd/server.go
+++ b/cmd/global-query/cmd/server.go
@@ -61,7 +61,7 @@ func serverEntrypoint(cmd *cobra.Command, args []string) error {
 		logger.With("error", err).Error("failed to set up tracing")
 	}
 
-	hostListResolver, err := initResolver(ctx)
+	hostListResolvers, err := initResolvers(ctx)
 	if err != nil {
 		logger.Errorf("failed to prepare host resolver: %v", err)
 		return err
@@ -79,7 +79,7 @@ func serverEntrypoint(cmd *cobra.Command, args []string) error {
 
 	// set up the API server
 	addr := viper.GetString(conf.ServerAddr)
-	apiServer := gqserver.New(addr, hostListResolver, querier,
+	apiServer := gqserver.New(addr, hostListResolvers, querier,
 		// Set the release mode of GIN depending on the log level
 		server.WithDebugMode(
 			logging.LevelFromString(viper.GetString(conf.LogLevel)) == logging.LevelDebug,

--- a/cmd/global-query/cmd/server.go
+++ b/cmd/global-query/cmd/server.go
@@ -20,16 +20,14 @@ import (
 	_ "github.com/els0r/goProbe/plugins/contrib/v4" // Include third-party plugins (if enabled, see README)
 )
 
-// serverCmd represents the server command
-var serverCmd = &cobra.Command{
-	Use:   "server",
-	Short: "Run global-query in server mode",
-	Long:  "Run global-query in server mode",
-	RunE:  serverEntrypoint,
-}
-
-func init() {
-	rootCmd.AddCommand(serverCmd)
+// serverCommand represents the server command
+func serverCommand() (*cobra.Command, error) {
+	serverCmd := &cobra.Command{
+		Use:   "server",
+		Short: "Run global-query in server mode",
+		Long:  "Run global-query in server mode",
+		RunE:  serverEntrypoint,
+	}
 
 	pflags := serverCmd.PersistentFlags()
 
@@ -41,10 +39,15 @@ func init() {
 	// telemetry
 	pflags.Bool(conf.ProfilingEnabled, false, "enable profiling endpoints")
 
-	_ = viper.BindPFlags(pflags)
+	err := viper.BindPFlags(pflags)
+	if err != nil {
+		return nil, err
+	}
+
+	return serverCmd, nil
 }
 
-func serverEntrypoint(cmd *cobra.Command, args []string) error {
+func serverEntrypoint(_ *cobra.Command, _ []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 	defer stop()
 

--- a/cmd/global-query/main.go
+++ b/cmd/global-query/main.go
@@ -1,7 +1,25 @@
 package main
 
-import "github.com/els0r/goProbe/v4/cmd/global-query/cmd"
+import (
+	"fmt"
+	"os"
+
+	"github.com/els0r/goProbe/v4/cmd/global-query/cmd"
+	"github.com/els0r/telemetry/logging"
+)
 
 func main() {
-	cmd.Execute()
+	err := cmd.Execute()
+	if err != nil {
+		logger, logErr := logging.New(logging.LevelError, logging.EncodingPlain,
+			logging.WithOutput(os.Stderr),
+		)
+		if logErr != nil {
+			fmt.Fprintf(os.Stderr, "Failed to instantiate CLI logger: %v\n", logErr)
+
+			fmt.Fprintf(os.Stderr, "Error running application: %s\n", err)
+			os.Exit(1)
+		}
+		logger.Fatalf("Error running application: %s", err)
+	}
 }

--- a/cmd/global-query/pkg/conf/conf.go
+++ b/cmd/global-query/pkg/conf/conf.go
@@ -16,7 +16,7 @@ const (
 	ServiceName = "global_query"
 )
 
-// Definnitions for command line parameters / arguments
+// Definitions for command line parameters / arguments
 const (
 	loggingKey  = "logging"
 	LogLevel    = loggingKey + ".level"

--- a/cmd/global-query/pkg/distributed/query.go
+++ b/cmd/global-query/pkg/distributed/query.go
@@ -15,7 +15,6 @@ import (
 	"github.com/els0r/goProbe/v4/pkg/query"
 	"github.com/els0r/goProbe/v4/pkg/results"
 	"github.com/els0r/goProbe/v4/pkg/types"
-	"github.com/els0r/goProbe/v4/plugins/resolver/stringresolver"
 	"github.com/els0r/telemetry/logging"
 	"github.com/els0r/telemetry/tracing"
 	"github.com/fako1024/gotools/concurrency"
@@ -34,9 +33,9 @@ const (
 // QueryRunner denotes a query runner / executor, wrapping a Querier interface instance with
 // other fields required to perform a distributed query
 type QueryRunner struct {
-	resolver hosts.Resolver
-	querier  distributed.Querier
-	sem      concurrency.Semaphore
+	resolvers *hosts.ResolverMap
+	querier   distributed.Querier
+	sem       concurrency.Semaphore
 }
 
 // QueryOption configures the query runner
@@ -50,15 +49,15 @@ func WithMaxConcurrent(sem chan struct{}) QueryOption {
 }
 
 // NewQueryRunner instantiates a new distributed query runner
-func NewQueryRunner(resolver hosts.Resolver, querier distributed.Querier, opts ...QueryOption) (qr *QueryRunner) {
+func NewQueryRunner(resolvers *hosts.ResolverMap, querier distributed.Querier, opts ...QueryOption) (qr *QueryRunner) {
 	qr = &QueryRunner{
-		resolver: resolver,
-		querier:  querier,
+		resolvers: resolvers,
+		querier:   querier,
 	}
 	for _, opt := range opts {
 		opt(qr)
 	}
-	return
+	return qr
 }
 
 // Run executes / runs the query and creates the final result structure
@@ -86,16 +85,15 @@ func (q *QueryRunner) run(ctx context.Context, args *query.Args, send sse.Sender
 		return nil, fmt.Errorf("couldn't prepare query: query for target hosts is empty")
 	}
 
-	// allows for overriding host resolution via a stringresolver if specified.
-	// This comes in handy when IDs are already available and will be used directly
-	// in the QueryHosts
-	//
-	// TODO: other resolvers are currently not forceable via the query args due to the
-	// complexity of their setup (e.g. a necessary config path)
-	var hostsResolver = q.resolver
-	if queryArgs.QueryHostsResolverType == stringresolver.Type {
-		hostsResolver = stringresolver.NewResolver(true)
-		logging.Logger().Info("using string resolver for hosts resolution")
+	// select hosts resolver based on query configuration. Will always fall back to the strings resolver in case none
+	// is selected
+	resolverType := "string"
+	if queryArgs.QueryHostsResolverType != "" {
+		resolverType = queryArgs.QueryHostsResolverType
+	}
+	hostsResolver, ok := q.resolvers.Get(resolverType)
+	if !ok {
+		return nil, fmt.Errorf("hosts resolver type %q not available", resolverType)
 	}
 
 	ctx, span := tracing.Start(ctx, "(*distributed.QueryRunner).run", trace.WithAttributes(attribute.String("args", queryArgs.ToJSONString())))
@@ -155,23 +153,24 @@ func (q *QueryRunner) prepareHostList(ctx context.Context, resolver hosts.Resolv
 
 	// Handle ANY (all hosts) case
 	if types.IsAnySelector(queryHosts) {
-		if querierAnyable, ok := q.querier.(distributed.QuerierAnyable); ok {
-			if hostList, err = querierAnyable.AllHosts(); err != nil {
-				err = fmt.Errorf("failed to extract list of all hosts: %w", err)
-			}
-		} else {
-			err = errors.New("querier type does not support querying all hosts")
+		querierAnyable, ok := q.querier.(distributed.QuerierAnyable)
+		if !ok {
+			return nil, errors.New("querier type does not support querying all hosts")
+		}
+		if hostList, err = querierAnyable.AllHosts(); err != nil {
+			return nil, fmt.Errorf("failed to extract list of all hosts: %w", err)
 		}
 
-		return
+		return hostList, nil
 	}
 
 	// Default handling via resolver
 	if hostList, err = resolver.Resolve(ctx, queryHosts); err != nil {
 		err = fmt.Errorf("failed to resolve host list: %w", err)
+		return nil, err
 	}
 
-	return
+	return hostList, nil
 }
 
 func (q *QueryRunner) checkSemaphore(stmt *query.Statement) (func(), error) {
@@ -188,15 +187,14 @@ func (q *QueryRunner) checkSemaphore(stmt *query.Statement) (func(), error) {
 	return q.sem.TryAddFor(semTimeout)
 }
 
-func (q *QueryRunner) forwardKeepalives(keepaliveChan <-chan struct{}, send sse.Sender, keepaliveInterval time.Duration) {
+func (*QueryRunner) forwardKeepalives(keepaliveChan <-chan struct{}, send sse.Sender, keepaliveInterval time.Duration) {
 	go func() {
 		lastKeepalive := time.Now()
 		for range keepaliveChan {
-
 			// assess time since last keepalive emission and act accordingly
 			if time.Since(lastKeepalive) > keepaliveInterval {
 				lastKeepalive = time.Now()
-				api.OnKeepalive(send)
+				_ = api.OnKeepalive(send)
 			}
 		}
 	}()
@@ -219,16 +217,16 @@ func aggregateResults(ctx context.Context, stmt *query.Statement, queryResults <
 	)
 
 	defer func() {
-		finalizeResult(finalResult, stmt, rowMap)
+		finalizeResult(finalResult, stmt, rowMap, stmt.NumResults) // fully honors the limit
 	}()
 
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return finalResult
 		case qr, open := <-queryResults:
 			if !open {
-				return
+				return finalResult
 			}
 			aggregateSingleResult(ctx, qr, finalResult, stmt, ifaceMap, rowMap, send)
 		}
@@ -288,7 +286,7 @@ func aggregateSingleResult(ctx context.Context, qr, finalResult *results.Result,
 	}
 
 	// for streaming, partial results must already include the current "final" state
-	finalizeResult(finalResult, stmt, rowMap)
+	finalizeResult(finalResult, stmt, rowMap, maxLimitStreaming) // caps the limit if it exceeds maxLimitStreaming
 
 	// if SSE callback is provided, run it
 	err := api.OnResult(finalResult, send)
@@ -297,7 +295,7 @@ func aggregateSingleResult(ctx context.Context, qr, finalResult *results.Result,
 	}
 }
 
-func finalizeResult(res *results.Result, stmt *query.Statement, rowMap results.RowsMap) {
+func finalizeResult(res *results.Result, stmt *query.Statement, rowMap results.RowsMap, limitUpperBound uint64) {
 	defer res.End()
 	if len(rowMap) == 0 {
 		return
@@ -306,7 +304,7 @@ func finalizeResult(res *results.Result, stmt *query.Statement, rowMap results.R
 	// assign the rows to the result
 	res.Rows = rowMap.ToRowsSorted(results.By(stmt.SortBy, stmt.Direction, stmt.SortAscending))
 
-	limit := min(stmt.NumResults, maxLimitStreaming)
+	limit := min(stmt.NumResults, limitUpperBound)
 
 	// truncate by limit
 	if limit < uint64(len(res.Rows)) {

--- a/examples/config/global-query-example-config-devcontainer.yaml
+++ b/examples/config/global-query-example-config-devcontainer.yaml
@@ -2,8 +2,10 @@ logging:
   level: debug
   encoding: logfmt
 hosts:
-  resolver:
-    type: string
+  resolvers:
+    - type: string
+    - type: static
+      config: ./examples/config/global-query-static-resolver-example-config-devcontainer.yaml
 querier:
   type: api
   max_concurrent: 64

--- a/examples/config/global-query-static-resolver-example-config-devcontainer.yaml
+++ b/examples/config/global-query-static-resolver-example-config-devcontainer.yaml
@@ -1,0 +1,2 @@
+ids:
+  - hostA

--- a/pkg/api/globalquery/server/server.go
+++ b/pkg/api/globalquery/server/server.go
@@ -16,18 +16,18 @@ import (
 
 // Server runs a global-query API server
 type Server struct {
-	hostListResolver hosts.Resolver
-	querier          distributed.Querier
+	hostListResolvers *hosts.ResolverMap
+	querier           distributed.Querier
 
 	*server.DefaultServer
 }
 
 // New creates a new global-query API server
-func New(addr string, resolver hosts.Resolver, querier distributed.Querier, opts ...server.Option) *Server {
+func New(addr string, resolvers *hosts.ResolverMap, querier distributed.Querier, opts ...server.Option) *Server {
 	server := &Server{
-		hostListResolver: resolver,
-		querier:          querier,
-		DefaultServer:    server.NewDefault(conf.ServiceName, addr, opts...),
+		hostListResolvers: resolvers,
+		querier:           querier,
+		DefaultServer:     server.NewDefault(conf.ServiceName, addr, opts...),
 	}
 
 	server.registerRoutes()
@@ -50,7 +50,7 @@ func (server *Server) registerRoutes() {
 	}
 	api.RegisterQueryAPI(server.API(),
 		fmt.Sprintf("global-query/%s", version.Short()),
-		gqdistributed.NewQueryRunner(server.hostListResolver, server.querier, opts...),
+		gqdistributed.NewQueryRunner(server.hostListResolvers, server.querier, opts...),
 		middlewares,
 	)
 }

--- a/pkg/distributed/hosts/resolver.go
+++ b/pkg/distributed/hosts/resolver.go
@@ -1,6 +1,9 @@
 package hosts
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
 // ID identifies a remote goProbe instance to query (host, FQDN, UUID, etc.).
 // If you already have an ID type elsewhere, feel free to replace this.
@@ -12,4 +15,40 @@ type Hosts []ID
 // Resolver returns the set of IDs that the distributed querier should contact
 type Resolver interface {
 	Resolve(ctx context.Context, query string) (Hosts, error)
+}
+
+// ResolverMap is a concurrency-safe map of named resolvers
+type ResolverMap struct {
+	mu        *sync.RWMutex
+	resolvers map[string]Resolver
+}
+
+// NewResolverMap creates a new ResolverMap
+func NewResolverMap() *ResolverMap {
+	return &ResolverMap{
+		mu:        &sync.RWMutex{},
+		resolvers: make(map[string]Resolver),
+	}
+}
+
+// Get returns the resolver for a given name in case it exists
+func (rm ResolverMap) Get(name string) (Resolver, bool) {
+	rm.mu.RLock()
+	resolver, ok := rm.resolvers[name]
+	rm.mu.RUnlock()
+	return resolver, ok
+}
+
+// Set sets the resolver for a given name
+func (rm ResolverMap) Set(name string, resolver Resolver) {
+	rm.mu.Lock()
+	rm.resolvers[name] = resolver
+	rm.mu.Unlock()
+}
+
+// Delete deletes an entry from the map
+func (rm ResolverMap) Delete(name string) {
+	rm.mu.Lock()
+	delete(rm.resolvers, name)
+	rm.mu.Unlock()
 }

--- a/pkg/e2etest/e2e_test.go
+++ b/pkg/e2etest/e2e_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/els0r/goProbe/v4/pkg/api/goprobe/client"
 	gpserver "github.com/els0r/goProbe/v4/pkg/api/goprobe/server"
 	"github.com/els0r/goProbe/v4/pkg/api/server"
+	"github.com/els0r/goProbe/v4/pkg/distributed/hosts"
 
 	"github.com/els0r/goProbe/v4/pkg/capture"
 	"github.com/els0r/goProbe/v4/pkg/capture/capturetypes"
@@ -697,7 +698,10 @@ func runGlobalQuery(t *testing.T, addr string, apiEndpoints map[string]string) f
 		endpoints[k] = &client.Config{Addr: v}
 	}
 
-	apiServer := gqserver.New(addr, stringresolver.NewResolver(true), &apiclient.APIClientQuerier{
+	resolvers := hosts.NewResolverMap()
+	resolvers.Set(stringresolver.NewResolver(true))
+
+	apiServer := gqserver.New(addr, resolvers, &apiclient.APIClientQuerier{
 		APIEndpoints:  endpoints,
 		MaxConcurrent: 10,
 	}, server.WithNoRecursionDetection())

--- a/plugins/resolver.go
+++ b/plugins/resolver.go
@@ -2,11 +2,29 @@ package plugins
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
 	"github.com/els0r/goProbe/v4/pkg/distributed/hosts"
+	"github.com/els0r/telemetry/logging"
 )
+
+// ResolverConfig is the configuration relevant for resolver plugin configuration
+type ResolverConfig struct {
+	Type   string `mapstructure:"type"`   // Type is the type of the resolver (e.g. the name)
+	Config string `mapstructure:"config"` // Config is the path to the configuration file
+}
+
+// HostResolverConfig holds all resolver configuration
+type HostResolverConfig struct {
+	Resolvers []*ResolverConfig `mapstructure:"resolvers"`
+}
+
+// AppConfig holds the application configuration configurable through viper only
+type AppConfig struct {
+	Hosts *HostResolverConfig `mapstructure:"hosts"`
+}
 
 // ResolverInitializer constructs a resolver, optionally using a config file.
 // Mirrors the existing QuerierInitializer pattern
@@ -42,6 +60,37 @@ func InitResolver(ctx context.Context, name, cfgPath string) (hosts.Resolver, er
 		return nil, fmt.Errorf("resolver plugin %q not registered", name)
 	}
 	return initFn(ctx, cfgPath)
+}
+
+// InitResolvers initializes all registered resolver plugins
+func InitResolvers(ctx context.Context, cfg *HostResolverConfig) (*hosts.ResolverMap, error) {
+	logger := logging.FromContext(ctx)
+
+	if cfg == nil {
+		return nil, errors.New("host resolver config is nil")
+	}
+
+	var rm = hosts.NewResolverMap()
+
+	for _, resolverCfg := range cfg.Resolvers {
+		if resolverCfg == nil {
+			logger.Warn("nil resolver config found")
+			continue
+		}
+		logger.WithGroup("resolver").With("type", resolverCfg.Type, "config", resolverCfg.Config).Info("initializing resolver")
+
+		name := resolverCfg.Type
+		initFn, exists := GetInitializer().getResolver(name)
+		if !exists {
+			return nil, fmt.Errorf("resolver plugin %q not registered", name)
+		}
+		resolver, err := initFn(ctx, resolverCfg.Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize resolver %q: %w", name, err)
+		}
+		rm.Set(name, resolver)
+	}
+	return rm, nil
 }
 
 // getResolver returns the resolver for a given name in case it exists

--- a/plugins/resolver/staticresolver/resolve.go
+++ b/plugins/resolver/staticresolver/resolve.go
@@ -43,12 +43,12 @@ func load(cfgPath string) (*Resolver, error) {
 	}
 	out := make(hosts.Hosts, 0, len(c.IDs))
 	for _, s := range c.IDs {
-		out = append(out, hosts.ID(s))
+		out = append(out, s)
 	}
 	return &Resolver{ids: out}, nil
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	plugins.RegisterResolver("static", func(_ context.Context, cfgPath string) (hosts.Resolver, error) {
 		return load(cfgPath)
 	})

--- a/plugins/resolver/staticresolver/resolve.go
+++ b/plugins/resolver/staticresolver/resolve.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/els0r/goProbe/v4/pkg/distributed/hosts"
 	"github.com/els0r/goProbe/v4/plugins"
-	jsoniter "github.com/json-iterator/go"
+	"gopkg.in/yaml.v3"
 )
 
-// Config file schema: {"ids": ["hostA","hostB", ...]}
+// Config file schema
 type Config struct {
-	IDs []string `json:"ids"`
+	IDs []string `yaml:"ids"`
 }
 
 // Resolver holds the pre-loaded host IDs from the configuration
@@ -35,7 +35,7 @@ func load(cfgPath string) (*Resolver, error) {
 		return nil, err
 	}
 	var c Config
-	if err := jsoniter.Unmarshal(b, &c); err != nil {
+	if err := yaml.Unmarshal(b, &c); err != nil {
 		return nil, err
 	}
 	if len(c.IDs) == 0 {

--- a/plugins/resolver_test.go
+++ b/plugins/resolver_test.go
@@ -1,0 +1,113 @@
+package plugins
+
+import (
+	"context"
+	"testing"
+
+	"github.com/els0r/goProbe/v4/pkg/distributed/hosts"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeResolver is a minimal implementation of hosts.Resolver for testing
+type fakeResolver struct {
+	name string
+	cfg  string
+}
+
+func (f *fakeResolver) Resolve(_ context.Context, query string) (hosts.Hosts, error) {
+	return hosts.Hosts{f.name + ":" + query}, nil
+}
+
+// helper to create an initializer that captures the cfgPath
+func makeFakeInitializer(name string) ResolverInitializer {
+	return func(_ context.Context, cfgPath string) (hosts.Resolver, error) {
+		return &fakeResolver{name: name, cfg: cfgPath}, nil
+	}
+}
+
+// resetResolvers clears the registered resolvers between tests to avoid cross-test interference
+func resetResolvers(tb testing.TB) {
+	tb.Helper()
+	initr := GetInitializer()
+	initr.Lock()
+	initr.resolvers = make(map[string]ResolverInitializer)
+	initr.Unlock()
+}
+
+func TestGetAvailableResolverPlugins_Sorted(t *testing.T) {
+	resetResolvers(t)
+	RegisterResolver("beta", makeFakeInitializer("beta"))
+	RegisterResolver("alpha", makeFakeInitializer("alpha"))
+
+	got := GetAvailableResolverPlugins()
+	want := []string{"alpha", "beta"}
+	require.Equal(t, want, got)
+}
+
+func TestInitResolver_Success(t *testing.T) {
+	resetResolvers(t)
+
+	RegisterResolver("foo", func(_ context.Context, cfgPath string) (hosts.Resolver, error) {
+		return &fakeResolver{name: "foo", cfg: cfgPath}, nil
+	})
+
+	r, err := InitResolver(context.Background(), "foo", "config.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	fr, ok := r.(*fakeResolver)
+	require.True(t, ok)
+	require.Equal(t, "config.yaml", fr.cfg)
+}
+
+func TestInitResolver_NotRegistered(t *testing.T) {
+	resetResolvers(t)
+	_, err := InitResolver(context.Background(), "does-not-exist", "")
+	require.Error(t, err)
+}
+
+func TestInitResolvers_NilConfig(t *testing.T) {
+	resetResolvers(t)
+	_, err := InitResolvers(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestInitResolvers_UnknownPlugin(t *testing.T) {
+	resetResolvers(t)
+	cfg := &HostResolverConfig{Resolvers: []*ResolverConfig{{Type: "unknown", Config: "cfg.yaml"}}}
+	_, err := InitResolvers(context.Background(), cfg)
+	require.Error(t, err)
+}
+
+func TestInitResolvers_Success_WithNilEntry(t *testing.T) {
+	resetResolvers(t)
+	RegisterResolver("alpha", makeFakeInitializer("alpha"))
+	RegisterResolver("beta", makeFakeInitializer("beta"))
+
+	cfg := &HostResolverConfig{Resolvers: []*ResolverConfig{
+		nil, // should be skipped
+		{Type: "alpha", Config: "a.yaml"},
+		{Type: "beta", Config: "b.yaml"},
+	}}
+
+	rm, err := InitResolvers(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, rm)
+
+	r, ok := rm.Get("alpha")
+	require.True(t, ok, "expected resolver 'alpha' to be present")
+	require.NotNil(t, r)
+	require.Equal(t, "a.yaml", r.(*fakeResolver).cfg)
+
+	r, ok = rm.Get("beta")
+	require.True(t, ok, "expected resolver 'beta' to be present")
+	require.NotNil(t, r)
+	require.Equal(t, "b.yaml", r.(*fakeResolver).cfg)
+}
+
+func TestRegisterResolver_DuplicatePanics(t *testing.T) {
+	resetResolvers(t)
+	RegisterResolver("dup", makeFakeInitializer("dup"))
+	require.Panics(t, func() {
+		RegisterResolver("dup", makeFakeInitializer("dup2"))
+	})
+}


### PR DESCRIPTION
More dynamic and exhaustive support for resolver plugin configuration.

Also fixes a bug introduced in https://github.com/els0r/goProbe/pull/402, where the upper bound on the row limit for SSE routes was applied to the final result of the query (which should of course honor the original limit).