### PR TITLE
[feature] Add support for interface autodetection

### DIFF
--- a/cmd/goProbe/config/config_test.go
+++ b/cmd/goProbe/config/config_test.go
@@ -170,6 +170,65 @@ func TestValidate(t *testing.T) {
 			},
 			errorInvalidAPIQueryRateLimit,
 		},
+		{"capture disabled with other settings",
+			&Config{
+				DB: DBConfig{Path: defaults.DBPath},
+				Interfaces: Ifaces{
+					"eth0": CaptureConfig{
+						Disable:    true,
+						Promisc:    true,
+						RingBuffer: &RingBufferConfig{BlockSize: 1024 * 1024, NumBlocks: 2},
+					},
+				},
+			},
+			errorSettingsWithCaptureDisabled,
+		},
+		{"capture disabled without other settings",
+			&Config{
+				DB: DBConfig{Path: defaults.DBPath},
+				Interfaces: Ifaces{
+					"eth0": CaptureConfig{
+						Disable: true,
+					},
+				},
+			},
+			nil,
+		},
+		{"autodetect interface validates configuration",
+			&Config{
+				DB: DBConfig{Path: defaults.DBPath},
+				Interfaces: Ifaces{
+					InterfaceAuto: CaptureConfig{
+						RingBuffer: &RingBufferConfig{BlockSize: 1024 * 1024, NumBlocks: 2},
+					},
+					"eth0": CaptureConfig{Disable: true},
+				},
+			},
+			nil,
+		},
+		{"autodetect requires other interfaces to be disabled",
+			&Config{
+				DB: DBConfig{Path: defaults.DBPath},
+				Interfaces: Ifaces{
+					InterfaceAuto: CaptureConfig{
+						RingBuffer: &RingBufferConfig{BlockSize: 1024 * 1024, NumBlocks: 2},
+					},
+					"eth0": CaptureConfig{
+						RingBuffer: &RingBufferConfig{BlockSize: 1024 * 1024, NumBlocks: 2},
+					},
+				},
+			},
+			errorIfaceMustBeDisabledWithAuto,
+		},
+		{"autodetect missing ring buffer",
+			&Config{
+				DB: DBConfig{Path: defaults.DBPath},
+				Interfaces: Ifaces{
+					InterfaceAuto: CaptureConfig{},
+				},
+			},
+			errorNoRingBufferConfig,
+		},
 	}
 
 	// run tests


### PR DESCRIPTION
Adds:

- `autodetect` "fake" interface name to signify usage of autodetection (using the provided interface config as default for all)
- Exclusion / veto concept via `disabled` option in individual interface config
- Automatic handling in `CaptureManager` upon instantiation / config reload if `autodetect` is enabled / provided

Closes #413 