### PR TITLE
[feature] Add multi-arch (arm64) builds for Docker images and release packages

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           target: sensor
           tags: goprobe/sensor:${{ env.COMMIT_SHA }},goprobe/sensor:${{ env.RELEASE_VERSION }},goprobe/sensor:latest
           build-args: |
@@ -48,6 +49,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           target: query
           tags: goprobe/query:${{ env.COMMIT_SHA }},goprobe/query:${{ env.RELEASE_VERSION }},goprobe/query:latest
           build-args: |
@@ -59,4 +61,5 @@ jobs:
         with:
           context: ./frontend/goquery-ui
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: goprobe/frontend:${{ env.COMMIT_SHA }},goprobe/frontend:${{ env.RELEASE_VERSION }},goprobe/frontend:latest

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -8,6 +8,19 @@ on:
 jobs:
   build-deb:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goarch: amd64
+            deb_arch: amd64
+            tarball_suffix: debian_amd64
+            cgo_enabled: "1"
+            depends: 'liblz4-1, libzstd1'
+          - goarch: arm64
+            deb_arch: arm64
+            tarball_suffix: debian_arm64
+            cgo_enabled: "0"
+            depends: ''
     steps:
 
       - name: Set up Go
@@ -29,13 +42,17 @@ jobs:
         run: |
           cd ./pkg/version && go generate
 
-      - name: Build for AMD64
+      - name: Build for ${{ matrix.goarch }}
+        env:
+          CGO_ENABLED: ${{ matrix.cgo_enabled }}
+          GOOS: linux
+          GOARCH: ${{ matrix.goarch }}
         run: |
-          GOOS=linux GOARCH=amd64 go build -a -tags jsoniter,slimcap_nomock -o goProbe -pgo=auto ./cmd/goProbe
-          GOOS=linux GOARCH=amd64 go build -a -tags jsoniter -o global-query -pgo=auto ./cmd/global-query
-          GOOS=linux GOARCH=amd64 go build -a -o goQuery -pgo=auto ./cmd/goQuery
-          GOOS=linux GOARCH=amd64 go build -a -o gpctl -pgo=auto ./cmd/gpctl
-          GOOS=linux GOARCH=amd64 go build -a -o goConvert ./cmd/goConvert
+          go build -a -tags jsoniter,slimcap_nomock -o goProbe -pgo=auto ./cmd/goProbe
+          go build -a -tags jsoniter -o global-query -pgo=auto ./cmd/global-query
+          go build -a -o goQuery -pgo=auto ./cmd/goQuery
+          go build -a -o gpctl -pgo=auto ./cmd/gpctl
+          go build -a -o goConvert ./cmd/goConvert
 
       - name: Deploy artifacts
         run: |
@@ -48,7 +65,7 @@ jobs:
           cp goQuery .debpkg/usr/local/bin/goQuery
           cp gpctl .debpkg/usr/local/bin/gpctl
           cp goConvert .debpkg/usr/local/bin/goConvert
-          tar czf ./goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz goProbe global-query goQuery gpctl goConvert
+          tar czf ./goprobe_${{ env.RELEASE_VERSION }}_${{ matrix.tarball_suffix }}.tar.gz goProbe global-query goQuery gpctl goConvert
 
           # Config
           cp examples/config/goprobe-example-config.yaml .debpkg/etc/goprobe.conf.example
@@ -68,21 +85,32 @@ jobs:
           package_root: .debpkg
           maintainer: fako1024
           version: ${{ github.ref }}
-          arch: 'amd64'
-          depends: 'liblz4-1, libzstd1'
+          arch: ${{ matrix.deb_arch }}
+          depends: ${{ matrix.depends }}
           desc: 'goProbe Network Traffic Monitoring'
 
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Debian
+          name: Debian-${{ matrix.deb_arch }}
           path: |
-            ./goprobe_${{ env.RELEASE_VERSION }}_amd64.deb
-            ./goprobe_${{ env.RELEASE_VERSION }}_debian_amd64.tar.gz
+            ./goprobe_${{ env.RELEASE_VERSION }}_${{ matrix.deb_arch }}.deb
+            ./goprobe_${{ env.RELEASE_VERSION }}_${{ matrix.tarball_suffix }}.tar.gz
 
   build-rpm:
     runs-on: ubuntu-latest
     container: fedora:37
+    strategy:
+      matrix:
+        include:
+          - goarch: amd64
+            rpm_arch: x86_64
+            tarball_suffix: fedora_x86_64
+            cgo_enabled: "1"
+          - goarch: arm64
+            rpm_arch: aarch64
+            tarball_suffix: fedora_aarch64
+            cgo_enabled: "0"
     steps:
 
       - name: Set up Go
@@ -107,13 +135,17 @@ jobs:
         run: |
           cd ./pkg/version && go generate
 
-      - name: Build for AMD64
+      - name: Build for ${{ matrix.goarch }}
+        env:
+          CGO_ENABLED: ${{ matrix.cgo_enabled }}
+          GOOS: linux
+          GOARCH: ${{ matrix.goarch }}
         run: |
-          GOOS=linux GOARCH=amd64 go build -a -tags jsoniter,slimcap_nomock -o goProbe -pgo=auto ./cmd/goProbe
-          GOOS=linux GOARCH=amd64 go build -a -tags jsoniter -o global-query -pgo=auto ./cmd/global-query
-          GOOS=linux GOARCH=amd64 go build -a -o goQuery -pgo=auto ./cmd/goQuery
-          GOOS=linux GOARCH=amd64 go build -a -o gpctl -pgo=auto ./cmd/gpctl
-          GOOS=linux GOARCH=amd64 go build -a -o goConvert ./cmd/goConvert
+          go build -a -tags jsoniter,slimcap_nomock -o goProbe -pgo=auto ./cmd/goProbe
+          go build -a -tags jsoniter -o global-query -pgo=auto ./cmd/global-query
+          go build -a -o goQuery -pgo=auto ./cmd/goQuery
+          go build -a -o gpctl -pgo=auto ./cmd/gpctl
+          go build -a -o goConvert ./cmd/goConvert
 
       - name: Deploy artifacts
         run: |
@@ -126,7 +158,7 @@ jobs:
           cp goQuery .rpmpkg/usr/local/bin/goQuery
           cp gpctl .rpmpkg/usr/local/bin/gpctl
           cp goConvert .rpmpkg/usr/local/bin/goConvert
-          tar czf ./goprobe_${{ env.RELEASE_VERSION }}_fedora_x86_64.tar.gz goProbe global-query goQuery gpctl goConvert
+          tar czf ./goprobe_${{ env.RELEASE_VERSION }}_${{ matrix.tarball_suffix }}.tar.gz goProbe global-query goQuery gpctl goConvert
 
           # Config
           cp examples/config/goprobe-example-config.yaml .rpmpkg/etc/goprobe.conf.example
@@ -137,20 +169,29 @@ jobs:
           package_root: .rpmpkg
           maintainer: fako1024
           version: ${{ github.ref }}
-          arch: 'x86_64'
+          arch: ${{ matrix.rpm_arch }}
           desc: 'goProbe Network Traffic Monitoring'
 
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Fedora
+          name: Fedora-${{ matrix.rpm_arch }}
           path: |
-            ./goprobe-${{ env.RELEASE_VERSION }}*x86_64.rpm
-            ./goprobe_${{ env.RELEASE_VERSION }}_fedora_x86_64.tar.gz
+            ./goprobe-${{ env.RELEASE_VERSION }}*${{ matrix.rpm_arch }}.rpm
+            ./goprobe_${{ env.RELEASE_VERSION }}_${{ matrix.tarball_suffix }}.tar.gz
 
   build-apk:
     runs-on: ubuntu-latest
     container: golang:1-alpine
+    strategy:
+      matrix:
+        include:
+          - goarch: amd64
+            tarball_suffix: alpine_x86_64
+            cgo_enabled: "1"
+          - goarch: arm64
+            tarball_suffix: alpine_aarch64
+            cgo_enabled: "0"
     steps:
 
       - name: Set environment
@@ -169,25 +210,28 @@ jobs:
         run: |
           cd ./pkg/version && go generate
 
-      - name: Build for AMD64
+      - name: Build for ${{ matrix.goarch }}
+        env:
+          CGO_ENABLED: ${{ matrix.cgo_enabled }}
+          GOOS: linux
+          GOARCH: ${{ matrix.goarch }}
         run: |
-          GOOS=linux GOARCH=amd64 go build -buildvcs=false -a -tags jsoniter,slimcap_nomock -o goProbe -pgo=auto ./cmd/goProbe
-          GOOS=linux GOARCH=amd64 go build -buildvcs=false -a -tags jsoniter -o global-query -pgo=auto ./cmd/global-query
-          GOOS=linux GOARCH=amd64 go build -buildvcs=false -a -o goQuery -pgo=auto ./cmd/goQuery
-          GOOS=linux GOARCH=amd64 go build -buildvcs=false -a -o gpctl -pgo=auto ./cmd/gpctl
-          GOOS=linux GOARCH=amd64 go build -buildvcs=false -a -o goConvert ./cmd/goConvert
-
+          go build -buildvcs=false -a -tags jsoniter,slimcap_nomock -o goProbe -pgo=auto ./cmd/goProbe
+          go build -buildvcs=false -a -tags jsoniter -o global-query -pgo=auto ./cmd/global-query
+          go build -buildvcs=false -a -o goQuery -pgo=auto ./cmd/goQuery
+          go build -buildvcs=false -a -o gpctl -pgo=auto ./cmd/gpctl
+          go build -buildvcs=false -a -o goConvert ./cmd/goConvert
 
       - name: Deploy artifacts
         run: |
-          tar czf ./goprobe_${{ env.RELEASE_VERSION }}_alpine_x86_64.tar.gz goProbe global-query goQuery gpctl goConvert
+          tar czf ./goprobe_${{ env.RELEASE_VERSION }}_${{ matrix.tarball_suffix }}.tar.gz goProbe global-query goQuery gpctl goConvert
 
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Alpine
+          name: Alpine-${{ matrix.goarch }}
           path: |
-            ./goprobe_${{ env.RELEASE_VERSION }}_alpine_x86_64.tar.gz
+            ./goprobe_${{ env.RELEASE_VERSION }}_${{ matrix.tarball_suffix }}.tar.gz
 
   build-openapi-specs:
     runs-on: ubuntu-latest
@@ -230,10 +274,10 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            downloaded-artifacts/Debian/goprobe*.deb
-            downloaded-artifacts/Debian/goprobe*.tar.gz
-            downloaded-artifacts/Fedora/goprobe*.rpm
-            downloaded-artifacts/Fedora/goprobe*.tar.gz
-            downloaded-artifacts/Alpine/goprobe*.tar.gz
+            downloaded-artifacts/Debian-*/goprobe*.deb
+            downloaded-artifacts/Debian-*/goprobe*.tar.gz
+            downloaded-artifacts/Fedora-*/goprobe*.rpm
+            downloaded-artifacts/Fedora-*/goprobe*.tar.gz
+            downloaded-artifacts/Alpine-*/goprobe*.tar.gz
             downloaded-artifacts/OpenAPI/*_openapi.yaml
           generate_release_notes: true

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -14,13 +14,13 @@ jobs:
           - goarch: amd64
             deb_arch: amd64
             tarball_suffix: debian_amd64
-            cgo_enabled: "1"
+            cc: gcc
             depends: 'liblz4-1, libzstd1'
           - goarch: arm64
             deb_arch: arm64
             tarball_suffix: debian_arm64
-            cgo_enabled: "0"
-            depends: ''
+            cc: aarch64-linux-gnu-gcc
+            depends: 'liblz4-1, libzstd1'
     steps:
 
       - name: Set up Go
@@ -38,13 +38,21 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
+      - name: Install ARM64 cross-compilation toolchain
+        if: matrix.goarch == 'arm64'
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu liblz4-dev:arm64 libzstd-dev:arm64
+
       - name: Generate version file in pkg/version using COMMIT_SHA and SEM_VER
         run: |
           cd ./pkg/version && go generate
 
       - name: Build for ${{ matrix.goarch }}
         env:
-          CGO_ENABLED: ${{ matrix.cgo_enabled }}
+          CGO_ENABLED: "1"
+          CC: ${{ matrix.cc }}
           GOOS: linux
           GOARCH: ${{ matrix.goarch }}
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 # Base image on Alpine / Golang
-FROM golang:1.26-alpine3.23 AS build
+# Always build on the host platform to enable native cross-compilation
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.23 AS build
 
-# Download system package dependencies
-RUN apk add cmake make gcc libtool git bash musl-dev zstd-dev lz4-dev
+# Download system package dependencies (no CGO libs needed: pure-Go lz4/zstd used)
+RUN apk add cmake make gcc libtool git bash musl-dev
+
+# Target platform args injected by Docker Buildx
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 
 # Upload source code
 WORKDIR /app
@@ -21,10 +26,10 @@ COPY . .
 ARG COMMIT_SHA=""
 ARG SEM_VER=""
 RUN cd ./pkg/version && go generate
-RUN nice -15 go build -tags jsoniter,slimcap_nomock -o goprobe -pgo=auto ./cmd/goProbe
-RUN nice -15 go build -tags jsoniter -o global-query -pgo=auto ./cmd/global-query
-RUN nice -15 go build -o goquery -pgo=auto ./cmd/goQuery
-RUN nice -15 go build -o gpctl -pgo=auto ./cmd/gpctl
+RUN nice -15 CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags jsoniter,slimcap_nomock -o goprobe -pgo=auto ./cmd/goProbe
+RUN nice -15 CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags jsoniter -o global-query -pgo=auto ./cmd/global-query
+RUN nice -15 CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o goquery -pgo=auto ./cmd/goQuery
+RUN nice -15 CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o gpctl -pgo=auto ./cmd/gpctl
 
 ###########################################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,8 @@
 # Base image on Alpine / Golang
-# Always build on the host platform to enable native cross-compilation
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.23 AS build
+FROM golang:1.26-alpine3.23 AS build
 
-# Download system package dependencies (no CGO libs needed: pure-Go lz4/zstd used)
-RUN apk add cmake make gcc libtool git bash musl-dev
-
-# Target platform args injected by Docker Buildx
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+# Download system package dependencies
+RUN apk add cmake make gcc libtool git bash musl-dev zstd-dev lz4-dev
 
 # Upload source code
 WORKDIR /app
@@ -26,10 +21,10 @@ COPY . .
 ARG COMMIT_SHA=""
 ARG SEM_VER=""
 RUN cd ./pkg/version && go generate
-RUN nice -15 CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags jsoniter,slimcap_nomock -o goprobe -pgo=auto ./cmd/goProbe
-RUN nice -15 CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags jsoniter -o global-query -pgo=auto ./cmd/global-query
-RUN nice -15 CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o goquery -pgo=auto ./cmd/goQuery
-RUN nice -15 CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o gpctl -pgo=auto ./cmd/gpctl
+RUN nice -15 go build -tags jsoniter,slimcap_nomock -o goprobe -pgo=auto ./cmd/goProbe
+RUN nice -15 go build -tags jsoniter -o global-query -pgo=auto ./cmd/global-query
+RUN nice -15 go build -o goquery -pgo=auto ./cmd/goQuery
+RUN nice -15 go build -o gpctl -pgo=auto ./cmd/gpctl
 
 ###########################################################################
 


### PR DESCRIPTION
## Summary

- **Docker images** (`Dockerfile` + `build-docker.yml`): all three images
  (`sensor`, `query`, `frontend`) are now published as multi-arch manifests
  covering `linux/amd64` and `linux/arm64`. QEMU was already wired up via
  `docker/setup-qemu-action`; the only required change was adding
  `platforms: linux/amd64,linux/arm64` to each `docker/build-push-action`
  step. The build stage runs under QEMU emulation for ARM64, so it links
  against the native arm64 lz4/zstd libraries — CGO is fully enabled on
  both architectures.

- **Debian packages** (`build-packages.yml`): the `build-deb` job is now a
  matrix over `amd64` and `arm64`. The arm64 build installs
  `gcc-aarch64-linux-gnu` + `liblz4-dev:arm64` + `libzstd-dev:arm64` via
  `dpkg --add-architecture arm64`, then compiles with
  `CC=aarch64-linux-gnu-gcc CGO_ENABLED=1` — producing a fully CGO-linked
  arm64 binary with the same `liblz4-1, libzstd1` runtime dependency as
  the amd64 package.

- **RPM packages**: matrix over `x86_64` and `aarch64`. The aarch64 build
  uses `CGO_ENABLED=0` (pure-Go lz4/zstd) because a musl/rpm
  cross-toolchain is not readily available in the `fedora:37` container.

- **Alpine tarballs**: same pattern — `amd64` (CGO enabled) and `arm64`
  (`CGO_ENABLED=0`).

- **Release job**: artifact glob patterns updated to `Debian-*/`,
  `Fedora-*/`, `Alpine-*/` so all architecture variants are attached to
  the GitHub release.

## Test plan

- [ ] Trigger a release tag and verify the Docker Hub manifests for
  `goprobe/query`, `goprobe/sensor`, and `goprobe/frontend` contain both
  `linux/amd64` and `linux/arm64` entries
- [ ] Confirm `docker pull goprobe/query:latest` on a Raspberry Pi 5
  selects the arm64 image
- [ ] Verify the GitHub release contains `*_arm64.deb`, `*_debian_arm64.tar.gz`,
  `*_fedora_aarch64.tar.gz`, and `*_alpine_aarch64.tar.gz` assets
- [ ] Install the arm64 `.deb` on a Raspberry Pi OS system and confirm
  the binaries run correctly
