### PR TITLE
[bugfix] Add minimal filepath.Clean for access to arbitrary config file

### DIFF
--- a/pkg/goDB/info/hostid_linux.go
+++ b/pkg/goDB/info/hostid_linux.go
@@ -5,6 +5,7 @@ package info
 
 import (
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -15,11 +16,11 @@ const (
 func hostID() (string, error) {
 
 	// Attempt to read the machine ID from the main file
-	idData, err := os.ReadFile(machineIDPath)
+	idData, err := os.ReadFile(filepath.Clean(machineIDPath))
 	if err != nil {
 
 		// Fallback to DBus based file
-		idData, err = os.ReadFile(machineIDDBusPath)
+		idData, err = os.ReadFile(filepath.Clean(machineIDDBusPath))
 		if err != nil {
 			return UnknownID, err
 		}

--- a/plugins/resolver/staticresolver/resolve.go
+++ b/plugins/resolver/staticresolver/resolve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 
 	"github.com/els0r/goProbe/v4/pkg/distributed/hosts"
 	"github.com/els0r/goProbe/v4/plugins"
@@ -30,7 +31,7 @@ func load(cfgPath string) (*Resolver, error) {
 		// Keep behavior graceful if no config is supplied: empty list.
 		return &Resolver{ids: nil}, nil
 	}
-	b, err := os.ReadFile(cfgPath)
+	b, err := os.ReadFile(filepath.Clean(cfgPath))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Note: The fix is really minimal, but:

- Aligns with what we do everywhere else in the repo (found one more occurrence where no sanitization was applied).
- The case isn't practically exploitable (no logging of content, even the output data is rebuild in memory from a sub-slice of the input config).
- Properly addressing would open a rats tail of complication at near zero actual improvement, so I'm calling diminishing returns here.

Closes #458 