### PR TITLE
[bugfix] Fix performance regression for host link detection and improve testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/els0r/telemetry/tracing v0.0.0-20260406010724-0c813ed6284d
 	github.com/fako1024/gotools/bitpack v0.0.0-20260108133916-d42cb4e89f05
 	github.com/fako1024/gotools/concurrency v0.0.0-20260108133916-d42cb4e89f05
-	github.com/fako1024/gotools/link v0.0.0-20260508092022-ce4a48edb845
+	github.com/fako1024/gotools/link v0.0.0-20260511092824-089d64760c34
 	github.com/fako1024/httpc v1.1.3
 	github.com/fako1024/slimcap v1.0.12
 	github.com/gin-contrib/cors v1.7.7
@@ -33,7 +33,7 @@ require (
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/net v0.53.0
-	golang.org/x/sys v0.43.0
+	golang.org/x/sys v0.44.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/fako1024/gotools v1.0.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,14 +27,10 @@ github.com/els0r/telemetry/metrics v0.0.0-20260406010724-0c813ed6284d h1:pc45XR2
 github.com/els0r/telemetry/metrics v0.0.0-20260406010724-0c813ed6284d/go.mod h1:V63AJPy62usGXhgifNIrPYrdBhor57wQd3/G+JTrg4E=
 github.com/els0r/telemetry/tracing v0.0.0-20260406010724-0c813ed6284d h1:zeMz/zS9zbSUcsXE6z5W6/IRzpaVjvnfn4U+YGD/lxI=
 github.com/els0r/telemetry/tracing v0.0.0-20260406010724-0c813ed6284d/go.mod h1:or6i2P/IjrEujjNenM9rcT5yMkBd7a1DUdWDw9v0Cds=
-github.com/fako1024/gotools v1.0.11 h1:Bor2L2gAQwhZeh1dllFWV/9Kq2pp0seaju3lUJJVuwU=
-github.com/fako1024/gotools v1.0.11/go.mod h1:foBo9vYEXD2f0S+NVi0/CL3z0geLsJ5tqv+cVmrE6ZU=
 github.com/fako1024/gotools/bitpack v0.0.0-20260108133916-d42cb4e89f05 h1:3VHEnPPCiqXfLn6IWoJ7emXjYoxmbMhXxZRA6b+cAoA=
 github.com/fako1024/gotools/bitpack v0.0.0-20260108133916-d42cb4e89f05/go.mod h1:OEC+qO4RGU1TTAN2uR1jcc7GXZTv3WA/G8nEU71Ezzs=
 github.com/fako1024/gotools/concurrency v0.0.0-20260108133916-d42cb4e89f05 h1:DZEPw0HElVshjsd7+OwNjmZIMLuTwAuywMZz0bdjLkE=
 github.com/fako1024/gotools/concurrency v0.0.0-20260108133916-d42cb4e89f05/go.mod h1:3ALRLl+moaiZInwD1FPHO3orrGm0U/E3tolgV9XaCEE=
-github.com/fako1024/gotools/link v0.0.0-20260108133916-d42cb4e89f05 h1:1vwXd29aFsCvPDBZUHokxvWkEsqwU/hwSmMx4S0hHiE=
-github.com/fako1024/gotools/link v0.0.0-20260108133916-d42cb4e89f05/go.mod h1:wQzxOmWgVXZFU6V0/ND3SwUyzywsPBlz2bFiq1H9p98=
 github.com/fako1024/gotools/link v0.0.0-20260508092022-ce4a48edb845 h1:RdG3qH/kC2fK7HWpThZm0qa77hFOyW+i2aT/qohWzxk=
 github.com/fako1024/gotools/link v0.0.0-20260508092022-ce4a48edb845/go.mod h1:wQzxOmWgVXZFU6V0/ND3SwUyzywsPBlz2bFiq1H9p98=
 github.com/fako1024/httpc v1.1.3 h1:2UbGhOgEMnkGnWCzT/pQH5eDAdO9FwfvBgZVK9fnoOA=

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/fako1024/gotools/concurrency v0.0.0-20260108133916-d42cb4e89f05 h1:DZ
 github.com/fako1024/gotools/concurrency v0.0.0-20260108133916-d42cb4e89f05/go.mod h1:3ALRLl+moaiZInwD1FPHO3orrGm0U/E3tolgV9XaCEE=
 github.com/fako1024/gotools/link v0.0.0-20260508092022-ce4a48edb845 h1:RdG3qH/kC2fK7HWpThZm0qa77hFOyW+i2aT/qohWzxk=
 github.com/fako1024/gotools/link v0.0.0-20260508092022-ce4a48edb845/go.mod h1:wQzxOmWgVXZFU6V0/ND3SwUyzywsPBlz2bFiq1H9p98=
+github.com/fako1024/gotools/link v0.0.0-20260511092824-089d64760c34 h1:Bj6TWHVA0Lqo/frf7XZuokDJchbkwPP3cn0/fk43J+s=
+github.com/fako1024/gotools/link v0.0.0-20260511092824-089d64760c34/go.mod h1:wQzxOmWgVXZFU6V0/ND3SwUyzywsPBlz2bFiq1H9p98=
 github.com/fako1024/httpc v1.1.3 h1:2UbGhOgEMnkGnWCzT/pQH5eDAdO9FwfvBgZVK9fnoOA=
 github.com/fako1024/httpc v1.1.3/go.mod h1:w50t2Sd4VPRju10ariSuz1942lmIgMq+w6CDef/BzI8=
 github.com/fako1024/slimcap v1.0.12 h1:r7X6xeIAnDC0yotno6SWfXKQfGFmF5ZymvCV6Jb615o=
@@ -242,6 +244,8 @@ golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=

--- a/pkg/capture/capture_manager.go
+++ b/pkg/capture/capture_manager.go
@@ -301,12 +301,6 @@ func (cm *Manager) Status(ctx context.Context, ifaces ...string) (statusmap capt
 
 // Update the configuration for all (or a set of) interfaces
 func (cm *Manager) Update(ctx context.Context, cfg *config.Config) (enabled, updated, disabled capturetypes.IfaceChanges, err error) {
-	allLinks, err := hostLinks()
-	if err != nil {
-		err = fmt.Errorf("failed to get host links: %w", err)
-		return
-	}
-
 	ifaces := cfg.Interfaces
 
 	// Autodetect interfaces if required
@@ -314,6 +308,12 @@ func (cm *Manager) Update(ctx context.Context, cfg *config.Config) (enabled, upd
 
 		// Validate the interface autodetectionconfiguration
 		if err = cfg.AutoDetection.Validate(); err != nil {
+			return
+		}
+
+		allLinks, lErr := hostLinks()
+		if lErr != nil {
+			err = fmt.Errorf("failed to get host links: %w", lErr)
 			return
 		}
 
@@ -337,6 +337,12 @@ func (cm *Manager) Update(ctx context.Context, cfg *config.Config) (enabled, upd
 
 	// If there are regexp matchers, find all matching interfaces and add them to the list
 	if hasRe {
+		allLinks, lErr := hostLinks()
+		if lErr != nil {
+			err = fmt.Errorf("failed to get host links: %w", lErr)
+			return
+		}
+
 		if ifaces, err = cm.filterMatchingIfaces(allLinks, matcher); err != nil {
 			return
 		}

--- a/pkg/capture/capture_manager_test.go
+++ b/pkg/capture/capture_manager_test.go
@@ -1,13 +1,26 @@
 package capture
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/els0r/goProbe/v4/cmd/goProbe/config"
 	"github.com/fako1024/gotools/link"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/els0r/goProbe/v4/pkg/capture/capturetypes"
 )
+
+type noopWriteoutHandler struct{}
+
+func (noopWriteoutHandler) HandleWriteout(context.Context, time.Time, <-chan capturetypes.TaggedAggFlowMap) <-chan struct{} {
+	done := make(chan struct{})
+	close(done)
+	return done
+}
 
 func TestAutodetectIfaces(t *testing.T) {
 	cm := &Manager{}
@@ -144,4 +157,114 @@ func TestFilterMatchingIfaces(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, matched)
+}
+
+func TestUpdateHostLinksUsage(t *testing.T) {
+	ctx := context.Background()
+	cm := NewManager(noopWriteoutHandler{})
+	cm.sourceInitFn = func(*Capture) (Source, error) {
+		return nil, fmt.Errorf("expected source init error in test")
+	}
+
+	stubLinks := link.Links{
+		&link.Link{Name: "eth0"},
+		&link.Link{Name: "eth1"},
+	}
+
+	defaultCfg := config.DefaultCaptureConfig()
+
+	tests := []struct {
+		name                  string
+		cfg                   *config.Config
+		expectedHostLinkCalls int
+	}{
+		{
+			name: "autodetection disabled without regex",
+			cfg: &config.Config{
+				Interfaces: config.Ifaces{
+					"eth0": defaultCfg,
+				},
+			},
+			expectedHostLinkCalls: 0,
+		},
+		{
+			name: "autodetection disabled with regex",
+			cfg: &config.Config{
+				Interfaces: config.Ifaces{
+					"/^eth[0-9]+$/": defaultCfg,
+				},
+			},
+			expectedHostLinkCalls: 1,
+		},
+		{
+			name: "autodetection enabled",
+			cfg: &config.Config{
+				AutoDetection: config.AutoDetectionConfig{Enabled: true},
+			},
+			expectedHostLinkCalls: 1,
+		},
+	}
+
+	originalHostLinks := hostLinks
+	t.Cleanup(func() { hostLinks = originalHostLinks })
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			hostLinks = func(...string) (link.Links, error) {
+				calls++
+				return stubLinks, nil
+			}
+
+			_, _, _, err := cm.Update(ctx, test.cfg)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedHostLinkCalls, calls)
+		})
+	}
+}
+
+func TestUpdateHostLinksErrorSurface(t *testing.T) {
+	ctx := context.Background()
+	cm := &Manager{}
+
+	originalHostLinks := hostLinks
+	t.Cleanup(func() { hostLinks = originalHostLinks })
+
+	hostLinks = func(...string) (link.Links, error) {
+		return nil, fmt.Errorf("boom")
+	}
+
+	defaultCfg := config.DefaultCaptureConfig()
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{
+			name: "regex branch",
+			cfg: &config.Config{
+				Interfaces: config.Ifaces{
+					"/^eth[0-9]+$/": defaultCfg,
+				},
+			},
+		},
+		{
+			name: "autodetection branch",
+			cfg: &config.Config{
+				AutoDetection: config.AutoDetectionConfig{Enabled: true},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			_, _, _, err := cm.Update(ctx, test.cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to get host links")
+			assert.Contains(t, err.Error(), "boom")
+		})
+	}
 }


### PR DESCRIPTION
## Summary
This PR fixes a performance regression in `pkg/capture/capture_manager.go` where `Manager.Update(...)` called `link.HostLinks(...)` unconditionally on every update/reload cycle.

This actually reverts changes / improvements introduced in the past to avoid long loading times > seconds on production hosts (e.g. hub locations) with large amounts of interfaces (>100).

As it turns out we both did our part here :rofl: 
```
The regression itself (unconditional hostLinks() in Manager.Update) was introduced in:
- 6de9ce137d539dcad86e8efc5a85c85c514abbf4
- Title: More fixes for auto-detection
- Author: Lennart Elsen (lelsen@open-systems.com)
- Date: 2025-12-02 07:52:36 +0000
It became a periodic overhead even without config-file reloads / was amplified by:
- 59597c62a5929b2a09342d85aae4e7e2341c3095
- Author: fako1024
- Date: 2025-12-22
- change: always re-apply config in monitor reload path.
```

## What changed
- Made host link enumeration lazy in `Manager.Update(...)`:
  - call `HostLinks` only in the autodetection branch
  - call `HostLinks` only when regex interface matchers are present in the static branch
  - skip `HostLinks` for static explicit interface configs (no autodetection, no regex)
- Added regression tests in `pkg/capture/capture_manager_test.go`:
  - `TestUpdateHostLinksUsage` (asserts call count: 0 for static, 1 for regex/autodetect)
  - `TestUpdateHostLinksErrorSurface` (verifies error wrapping in branches that still call `HostLinks`)
- Also bumps `gotools/link` with improvements for link detection from https://github.com/fako1024/gotools/pull/24

## Result
Static non-autodetection/non-regex setups no longer perform unnecessary periodic host interface scans during config re-apply.

# TODO

- [x] Once https://github.com/fako1024/gotools/pull/24 is merged, bump dependency.

Closes #468 