### PR TITLE
[feature] Frontend: add Helm chart for deploying goquery-ui frontend

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -83,3 +83,37 @@ jobs:
     - name: Test (Race Detector enabled)
       run: |
         go test -tags jsoniter -race -v ./...
+
+  lint-chart:
+    name: Lint Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0   # ct needs history to diff the chart against the target branch
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+
+    - name: helm lint
+      run: helm lint charts/goquery-ui
+
+    - name: helm template
+      # backend.url is a required value with no default, so supply a representative
+      # one to exercise full template rendering.
+      run: helm template charts/goquery-ui --set backend.url=http://global-query.observability.svc.cluster.local:8145
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@v2
+
+    - name: ct lint
+      run: |
+        ct lint --charts charts/goquery-ui \
+          --target-branch ${{ github.event.repository.default_branch }} \
+          --check-version-increment

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -113,7 +113,11 @@ jobs:
       uses: helm/chart-testing-action@v2
 
     - name: ct lint
+      # Detect changed charts by diffing against the target branch (no --charts), so
+      # --check-version-increment is actually enforced. Maintainer is a team label with
+      # a URL rather than a GitHub handle, so skip maintainer-as-user validation.
       run: |
-        ct lint --charts charts/goquery-ui \
+        ct lint \
           --target-branch ${{ github.event.repository.default_branch }} \
-          --check-version-increment
+          --check-version-increment \
+          --validate-maintainers=false

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -1,0 +1,52 @@
+name: Publish Helm Chart
+
+# Decoupled from the app's v*.*.* release tags: the chart carries its own semver
+# in charts/goquery-ui/Chart.yaml. On every push to main that touches the chart,
+# we package it and publish to GHCR as an OCI artifact — but only if that exact
+# version isn't already published. The registry is the source of truth, so a
+# failed run self-heals on the next push and an already-shipped version is never
+# clobbered.
+
+on:
+  push:
+    branches: [main]
+    paths: ['charts/goquery-ui/**']
+
+jobs:
+  publish-chart:
+    name: Package & Publish to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR
+        run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read chart version
+        id: chart
+        run: echo "version=$(helm show chart charts/goquery-ui | yq '.version')" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether this version is already published
+        id: exists
+        run: |
+          if helm show chart oci://ghcr.io/els0r/charts/goquery-ui \
+               --version "${{ steps.chart.outputs.version }}" >/dev/null 2>&1; then
+            echo "Chart goquery-ui ${{ steps.chart.outputs.version }} is already published — nothing to do."
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Chart goquery-ui ${{ steps.chart.outputs.version }} is not yet published."
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Package & push
+        if: steps.exists.outputs.published == 'false'
+        run: |
+          helm package charts/goquery-ui          # version straight from Chart.yaml
+          helm push goquery-ui-*.tgz oci://ghcr.io/els0r/charts

--- a/charts/goquery-ui/.helmignore
+++ b/charts/goquery-ui/.helmignore
@@ -1,0 +1,11 @@
+# Patterns to ignore when building Helm packages.
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+*.bak
+*.swp
+*.orig
+.idea/
+.vscode/
+ci/

--- a/charts/goquery-ui/Chart.yaml
+++ b/charts/goquery-ui/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: goquery-ui
+description: |
+  goquery-ui — the goProbe network-flow exploration frontend. A static SPA
+  served by Caddy that reverse-proxies the global-query backend API. Designed
+  to run behind a gateway: ships a ClusterIP Service with a named http port
+  and brings no Ingress/Gateway/VirtualService of its own — external routing is
+  the deployer's responsibility.
+type: application
+
+# Chart's own semver — bump on chart changes.
+version: 0.1.0
+
+# Version of the goprobe/frontend image this chart was validated against.
+# image.tag defaults to this value.
+appVersion: "4.2.11"
+
+home: https://github.com/els0r/goProbe
+sources:
+  - https://github.com/els0r/goProbe/tree/main/frontend/goquery-ui
+keywords:
+  - goprobe
+  - goquery
+  - network-observability
+  - frontend
+  - spa
+maintainers:
+  - name: goProbe maintainers
+    url: https://github.com/els0r/goProbe

--- a/charts/goquery-ui/README.md
+++ b/charts/goquery-ui/README.md
@@ -30,14 +30,14 @@ render without it.
 
 ```bash
 helm install goquery-ui ./charts/goquery-ui \
-  --namespace observability --create-namespace \
-  --set backend.url=http://global-query.observability.svc.cluster.local:8145
+  --namespace network-observability --create-namespace \
+  --set backend.url=http://global-query.network-observability.svc.cluster.local:8145
 ```
 
 Verify locally without any routing:
 
 ```bash
-kubectl -n observability port-forward svc/goquery-ui 8080:80
+kubectl -n network-observability port-forward svc/goquery-ui 8080:80
 # open http://localhost:8080
 ```
 

--- a/charts/goquery-ui/README.md
+++ b/charts/goquery-ui/README.md
@@ -1,0 +1,60 @@
+# goquery-ui Helm chart
+
+Deploys [goquery-ui](../../frontend/goquery-ui) — the goProbe network-flow
+exploration frontend — into Kubernetes.
+
+The image (`goprobe/frontend`) is a static SPA served by **Caddy** on port
+`5137`. Caddy reverse-proxies the global-query backend so the browser only ever
+makes same-origin requests. The chart is **frontend-only**: it assumes the
+backend already runs as a Service you can reach in-cluster.
+
+## Design
+
+- **Minimal, routing-agnostic.** Ships a `ClusterIP` Service with a named
+  `http` port and *no* Ingress/Gateway/VirtualService. External routing is the
+  deployer's responsibility — wire it up with whatever your cluster uses
+  (Kubernetes `Ingress`, a service-mesh gateway, etc.; see `helm install` NOTES
+  output). The Caddyfile keeps `auto_https off`; TLS terminates upstream at the
+  gateway.
+- **Hardened by default.** Non-root (uid/gid 1000), all capabilities dropped,
+  `readOnlyRootFilesystem`, seccomp `RuntimeDefault`. Writable paths
+  (`/var/run/env`, `/tmp`, `/data`, `/config`) are backed by `emptyDir`.
+- **Config rolls pods.** Runtime settings live in a ConfigMap; a
+  `checksum/config` annotation restarts pods on change (env.js is generated once
+  at container startup).
+
+## Install
+
+`backend.url` is **required** — there is no safe default. The chart fails to
+render without it.
+
+```bash
+helm install goquery-ui ./charts/goquery-ui \
+  --namespace observability --create-namespace \
+  --set backend.url=http://global-query.observability.svc.cluster.local:8145
+```
+
+Verify locally without any routing:
+
+```bash
+kubectl -n observability port-forward svc/goquery-ui 8080:80
+# open http://localhost:8080
+```
+
+## Key values
+
+| Key | Default | Description |
+|---|---|---|
+| `backend.url` | `""` (**required**) | Caddy reverse-proxy target → `GQ_BACKEND_HOST`. |
+| `config.apiBaseUrl` | `""` | Browser API base URL. Empty = same-origin proxy (recommended). |
+| `config.hostResolverTypes` | `"string"` | Resolver types shown in the UI. |
+| `config.sseOnLoad` | `"true"` | Enable SSE streaming by default. |
+| `replicaCount` | `2` | Replicas (ignored when autoscaling is enabled). |
+| `image.repository` / `image.tag` | `goprobe/frontend` / `""`→appVersion | Image. |
+| `service.type` / `service.port` / `service.portName` | `ClusterIP` / `80` / `http` | Service. |
+| `autoscaling.enabled` | `false` | HorizontalPodAutoscaler (needs metrics-server). |
+| `pdb.enabled` | `false` | PodDisruptionBudget (`minAvailable: 1`). |
+| `serviceAccount.automount` | `false` | SA token mount (SPA needs no API access). |
+| `resources` | 50m/64Mi → 200m/128Mi | Requests / limits. |
+
+See [values.yaml](./values.yaml) for the full set.

--- a/charts/goquery-ui/templates/NOTES.txt
+++ b/charts/goquery-ui/templates/NOTES.txt
@@ -1,0 +1,39 @@
+goquery-ui {{ .Chart.AppVersion }} deployed as release "{{ .Release.Name }}".
+
+The frontend is exposed in-cluster as a ClusterIP Service:
+
+    {{ include "goquery-ui.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}  (port name: {{ .Values.service.portName }})
+
+This chart ships no Ingress/Gateway/VirtualService — external routing is the
+deployer's responsibility. Point your cluster's routing at the Service above,
+e.g. with a Kubernetes Ingress:
+
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: goquery-ui
+    spec:
+      rules:
+        - host: goquery.example.com
+          http:
+            paths:
+              - path: /
+                pathType: Prefix
+                backend:
+                  service:
+                    name: {{ include "goquery-ui.fullname" . }}
+                    port:
+                      number: {{ .Values.service.port }}
+
+(or the equivalent Gateway/VirtualService if you run a service mesh).
+
+Backend (Caddy reverse-proxy target):
+
+    GQ_BACKEND_HOST = {{ .Values.backend.url }}
+
+Browser API routing: {{ if .Values.config.apiBaseUrl }}direct to {{ .Values.config.apiBaseUrl }}{{ else }}same-origin via the Caddy proxy (recommended){{ end }}
+
+Quick local check (no routing needed):
+
+    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "goquery-ui.fullname" . }} 8080:{{ .Values.service.port }}
+    # then open http://localhost:8080

--- a/charts/goquery-ui/templates/_helpers.tpl
+++ b/charts/goquery-ui/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "goquery-ui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec).
+*/}}
+{{- define "goquery-ui.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "goquery-ui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "goquery-ui.labels" -}}
+helm.sh/chart: {{ include "goquery-ui.chart" . }}
+{{ include "goquery-ui.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "goquery-ui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "goquery-ui.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+The image reference, with tag defaulting to the chart appVersion.
+*/}}
+{{- define "goquery-ui.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}
+
+{{/*
+The name of the ServiceAccount to use.
+*/}}
+{{- define "goquery-ui.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "goquery-ui.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/goquery-ui/templates/configmap.yaml
+++ b/charts/goquery-ui/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "goquery-ui.fullname" . }}
+  labels:
+    {{- include "goquery-ui.labels" . | nindent 4 }}
+data:
+  # Caddy reverse-proxy target. Consumed by the Caddyfile.
+  GQ_BACKEND_HOST: {{ .Values.backend.url | quote }}
+  # Runtime UI settings, rendered into env.js at container startup.
+  GQ_API_BASE_URL: {{ .Values.config.apiBaseUrl | quote }}
+  HOST_RESOLVER_TYPES: {{ .Values.config.hostResolverTypes | quote }}
+  SSE_ON_LOAD: {{ .Values.config.sseOnLoad | quote }}

--- a/charts/goquery-ui/templates/deployment.yaml
+++ b/charts/goquery-ui/templates/deployment.yaml
@@ -1,0 +1,94 @@
+{{- if not .Values.backend.url }}
+{{- fail "backend.url is required: set it to your in-cluster global-query backend, e.g. --set backend.url=http://global-query.observability.svc.cluster.local:8145" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "goquery-ui.fullname" . }}
+  labels:
+    {{- include "goquery-ui.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "goquery-ui.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Roll pods when the ConfigMap changes — env.js is generated once at
+        # container startup, so a config change requires a restart.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "goquery-ui.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "goquery-ui.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "goquery-ui.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "goquery-ui.fullname" . }}
+          ports:
+            - name: http
+              containerPort: 5137
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          # readOnlyRootFilesystem is on — back every path Caddy/entrypoint
+          # write to with an emptyDir.
+          volumeMounts:
+            - name: env
+              mountPath: /var/run/env
+            - name: tmp
+              mountPath: /tmp
+            - name: caddy-data
+              mountPath: /data
+            - name: caddy-config
+              mountPath: /config
+      volumes:
+        - name: env
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: caddy-data
+          emptyDir: {}
+        - name: caddy-config
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/goquery-ui/templates/hpa.yaml
+++ b/charts/goquery-ui/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "goquery-ui.fullname" . }}
+  labels:
+    {{- include "goquery-ui.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "goquery-ui.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/goquery-ui/templates/pdb.yaml
+++ b/charts/goquery-ui/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "goquery-ui.fullname" . }}
+  labels:
+    {{- include "goquery-ui.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "goquery-ui.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/goquery-ui/templates/service.yaml
+++ b/charts/goquery-ui/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "goquery-ui.fullname" . }}
+  labels:
+    {{- include "goquery-ui.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      # "http"-prefixed name lets gateways/meshes do HTTP protocol detection / L7 routing.
+      name: {{ .Values.service.portName }}
+  selector:
+    {{- include "goquery-ui.selectorLabels" . | nindent 4 }}

--- a/charts/goquery-ui/templates/serviceaccount.yaml
+++ b/charts/goquery-ui/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "goquery-ui.serviceAccountName" . }}
+  labels:
+    {{- include "goquery-ui.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/goquery-ui/values.yaml
+++ b/charts/goquery-ui/values.yaml
@@ -1,0 +1,141 @@
+# Default values for goquery-ui.
+# This is a YAML-formatted file. Declare variables to be passed into templates.
+
+# -- Number of frontend replicas (stateless; safe to spread).
+replicaCount: 2
+
+image:
+  # -- Image repository for the goProbe frontend.
+  repository: goprobe/frontend
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+  # -- Image tag. Defaults to the chart's appVersion when left empty.
+  tag: ""
+
+# -- Image pull secrets for private registries.
+imagePullSecrets: []
+# -- Override the chart name used in resource names.
+nameOverride: ""
+# -- Override the fully-qualified app name used in resource names.
+fullnameOverride: ""
+
+# ----------------------------------------------------------------------------
+# Backend wiring (REQUIRED)
+# ----------------------------------------------------------------------------
+backend:
+  # -- URL of the global-query backend that Caddy reverse-proxies to
+  # (becomes GQ_BACKEND_HOST). Point this at your in-cluster backend Service,
+  # e.g. http://global-query.observability.svc.cluster.local:8145
+  # The chart fails to render if this is empty — there is no safe default.
+  url: ""
+
+# ----------------------------------------------------------------------------
+# Runtime UI configuration (injected into env.js at container startup)
+# ----------------------------------------------------------------------------
+config:
+  # -- URL the *browser* uses to reach the API. Leave empty to route through
+  # the Caddy same-origin reverse proxy (recommended; preserves the CSP).
+  apiBaseUrl: ""
+  # -- Comma-separated host resolver types offered in the UI.
+  hostResolverTypes: "string"
+  # -- Enable SSE streaming by default ("true"/"false").
+  sseOnLoad: "true"
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- Mount the SA token. The SPA never calls the Kubernetes API, so this is
+  # off by default to reduce blast radius.
+  automount: false
+  # -- Annotations to add to the ServiceAccount.
+  annotations: {}
+  # -- ServiceAccount name. Generated from the fullname if empty.
+  name: ""
+
+# -- Annotations added to the pod template. A checksum/config annotation is
+# always added on top of these to roll pods when the ConfigMap changes.
+podAnnotations: {}
+# -- Labels added to the pod template.
+podLabels: {}
+
+# -- Pod-level security context.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container-level security context. Mirrors the hardened docker-compose
+# setup (no-new-privileges, read-only rootfs). Writable paths are backed by
+# emptyDir volumes (see the deployment template).
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  # -- Service type. ClusterIP is correct when routing is added out-of-band.
+  type: ClusterIP
+  # -- Service port exposed in-cluster.
+  port: 80
+  # -- Name of the service port. Keep the "http" prefix so gateways/meshes can
+  # perform HTTP protocol detection and L7 routing.
+  portName: http
+  # -- Annotations to add to the Service.
+  annotations: {}
+
+# -- Resource requests/limits. Caddy serving static files is lightweight.
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+# Liveness/readiness both probe `GET /` on the http port: Caddy serves
+# index.html with 200 as soon as it's up, independent of backend health.
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 15
+  timeoutSeconds: 3
+  failureThreshold: 3
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 3
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+autoscaling:
+  # -- Enable a HorizontalPodAutoscaler (requires metrics-server).
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  # -- Target memory utilization percentage (set to enable memory scaling).
+  targetMemoryUtilizationPercentage: 0
+
+pdb:
+  # -- Enable a PodDisruptionBudget.
+  enabled: false
+  # -- minAvailable for the PDB. Set maxUnavailable instead if preferred.
+  minAvailable: 1
+  maxUnavailable: ""
+
+# -- Scheduling controls (all passthrough, empty by default).
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []

--- a/docs/adr/0001-goquery-ui-chart-ships-no-in-cluster-routing.md
+++ b/docs/adr/0001-goquery-ui-chart-ships-no-in-cluster-routing.md
@@ -1,0 +1,55 @@
+# 1. goquery-ui Helm chart ships no in-cluster routing
+
+Date: 2026-06-16
+
+## Status
+
+Accepted
+
+## Context
+
+The `charts/goquery-ui` Helm chart deploys the goProbe frontend
+(`goprobe/frontend`) — a static SPA served by Caddy on port 5137. The chart
+needs to make the UI reachable, and there are several ways to express that in a
+chart: a Kubernetes `Ingress`, a service-mesh `Gateway` + route resources, or
+nothing at all (just a `ClusterIP` Service).
+
+Two facts constrain the choice:
+
+- The runtime is built to sit **behind a gateway**. The Caddyfile sets
+  `auto_https off` ("We're behind an Ingress; don't manage TLS here") — TLS and
+  external routing are expected to terminate upstream.
+- External routing is the **deployer's responsibility**, and the mechanism
+  varies per environment: a Kubernetes `Ingress`, a service mesh, or a
+  cloud load balancer. Bundling any one of these would pin the chart to a
+  specific API (and, for a mesh, to CRD versions, a gateway name, and a
+  topology the chart cannot know). Whatever the deployer uses, the chart's job
+  is the same: expose the UI over HTTP in-cluster.
+
+A chart that bundles routing is more "batteries-included" for a first install,
+but it couples the chart's lifecycle to the cluster's routing API versions and
+topology, which churn independently of the frontend.
+
+## Decision
+
+The chart ships **only** a `ClusterIP` Service with a named `http` port (so a
+gateway/mesh can perform HTTP protocol detection and L7 routing) plus the
+Deployment and its supporting objects. It bundles **no** `Ingress`, `Gateway`,
+or route resources.
+
+Operators wire external access out-of-band with whatever their cluster uses. The
+`helm install` NOTES output prints a ready-to-adapt `Ingress` snippet and a
+`kubectl port-forward` command for verification without any routing.
+
+## Consequences
+
+- The chart stays decoupled from any particular routing API, gateway name, or
+  mesh topology; it works under a Kubernetes `Ingress`, a service mesh, a cloud
+  load balancer, or bare `port-forward`.
+- A bare `helm install` yields a UI reachable only in-cluster — there is one
+  required manual step (routing) before it is externally reachable. This is
+  surfaced in the chart README and NOTES.
+- If a future deployment target standardises on a single routing topology, an
+  optional, off-by-default routing template could be added without breaking
+  existing installs. Reversible in that direction; the current choice does not
+  lock it out.


### PR DESCRIPTION
Adds charts/goquery-ui, a frontend-only Helm chart for the goprobe/frontend image (Caddy-served SPA on port 5137). Designed to sit behind a gateway: ships a ClusterIP Service with a named http port and no Ingress/Gateway/VirtualService — external routing is the deployer's responsibility.

- backend.url is required (Caddy reverse-proxy target, GQ_BACKEND_HOST); render fails fast if unset.
- Runtime settings (GQ_API_BASE_URL, HOST_RESOLVER_TYPES, SSE_ON_LOAD) come from a ConfigMap with a checksum/config annotation to roll pods on change.
- Hardened pod: non-root 1000, drop ALL caps, readOnlyRootFilesystem, seccomp RuntimeDefault, with emptyDir for /var/run/env, /tmp, /data, /config.
- Liveness/readiness probe GET / on the http port; dedicated ServiceAccount with token automount off; optional HPA and PDB, both off by default.

Records the no-in-cluster-routing decision in docs/adr/0001.

## Packaging & distribution

The chart is published from CI so it can be consumed as a dependency instead of copied by directory.

- **Publish workflow** (`.github/workflows/publish-chart.yml`): on push to `main` touching `charts/goquery-ui/**`, packages the chart and pushes it to GHCR as an OCI artifact at `oci://ghcr.io/els0r/charts/goquery-ui`. Publishing is **existence-checked, not diff-triggered** — it ships only when the `Chart.yaml` `version:` is not already in the registry, so a failed run self-heals on the next push and an already-published version is never clobbered. Uses the built-in `GITHUB_TOKEN` (`packages: write`); no new secret required.
- **Decoupled versioning**: the chart carries its own semver in `Chart.yaml`, independent of the app's `v*.*.*` release tags. Bump `version:` to ship; that field is the single source of truth.
- **PR lint** (`lint-chart` in `ci-pr.yml`): `helm lint` + `helm template` (with a representative `backend.url`) + `ct lint --check-version-increment`, so chart breakage and missing version bumps fail review.

Consumers then declare it as a dependency:

```yaml
dependencies:
  - name: goquery-ui
    version: 0.1.0
    repository: oci://ghcr.io/els0r/charts
```

> [!NOTE]
> One-time GHCR setup after the first publish: the package is created **private** and owned by the user. Set its visibility to **public** (anonymous `helm pull`) and link it to the repo in the GHCR package settings — this can't be done from the workflow.