### PR TITLE
[bugfix] Frontend: rewrite proxy Host header for Istio mesh routing

### DIFF
--- a/charts/goquery-ui/Chart.yaml
+++ b/charts/goquery-ui/Chart.yaml
@@ -9,7 +9,7 @@ description: |
 type: application
 
 # Chart's own semver — bump on chart changes.
-version: 0.1.2
+version: 0.1.3
 
 # Version of the goprobe/frontend image this chart was validated against.
 # image.tag defaults to this value.

--- a/charts/goquery-ui/Chart.yaml
+++ b/charts/goquery-ui/Chart.yaml
@@ -9,7 +9,7 @@ description: |
 type: application
 
 # Chart's own semver — bump on chart changes.
-version: 0.1.3
+version: 0.1.2
 
 # Version of the goprobe/frontend image this chart was validated against.
 # image.tag defaults to this value.

--- a/frontend/goquery-ui/deploy/Caddyfile
+++ b/frontend/goquery-ui/deploy/Caddyfile
@@ -47,8 +47,17 @@
 	# so no CORS headers are required on the backend for browser traffic.
 	# GQ_BACKEND_HOST must be set in the container environment, e.g.
 	#   GQ_BACKEND_HOST=http://global-query:8145
-	reverse_proxy /_query* {$GQ_BACKEND_HOST}
-	reverse_proxy /-/* {$GQ_BACKEND_HOST}
+	#
+	# header_up Host rewrites the Host header to the backend's hostport instead
+	# of preserving the browser's external Host. This is required behind service
+	# meshes like Istio, whose sidecar routes by Host: an unrecognized external
+	# host falls through to PassthroughCluster and fails with 503 (see #478).
+	reverse_proxy /_query* {$GQ_BACKEND_HOST} {
+		header_up Host {http.reverse_proxy.upstream.hostport}
+	}
+	reverse_proxy /-/* {$GQ_BACKEND_HOST} {
+		header_up Host {http.reverse_proxy.upstream.hostport}
+	}
 
 	# Serve static files first
 	file_server


### PR DESCRIPTION
Caddy's reverse_proxy preserved the browser's original Host header
(the external hostname) when proxying /_query* and /-/* to the backend.
Behind an Istio service mesh, the sidecar routes by Host: an unrecognized
external host falls through to PassthroughCluster and fails with 503.

Add `header_up Host {http.reverse_proxy.upstream.hostport}` so the proxied
request carries the backend's hostport, letting the mesh route it to the
correct cluster.

Fixes #478

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>