### PR TITLE
[bugfix] Frontend: make Caddy listen address configurable, secure by default

### DIFF
--- a/charts/goquery-ui/Chart.yaml
+++ b/charts/goquery-ui/Chart.yaml
@@ -9,7 +9,7 @@ description: |
 type: application
 
 # Chart's own semver — bump on chart changes.
-version: 0.1.2
+version: 0.1.3
 
 # Version of the goprobe/frontend image this chart was validated against.
 # image.tag defaults to this value.

--- a/charts/goquery-ui/Chart.yaml
+++ b/charts/goquery-ui/Chart.yaml
@@ -9,7 +9,7 @@ description: |
 type: application
 
 # Chart's own semver — bump on chart changes.
-version: 0.1.3
+version: 0.1.4
 
 # Version of the goprobe/frontend image this chart was validated against.
 # image.tag defaults to this value.

--- a/charts/goquery-ui/templates/configmap.yaml
+++ b/charts/goquery-ui/templates/configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "goquery-ui.labels" . | nindent 4 }}
 data:
+  # Caddy bind address. Consumed by the Caddyfile. Keep this bound to all
+  # interfaces so the kubelet probes and the Service can reach the pod by IP.
+  GQ_LISTEN_ADDR: {{ .Values.config.listenAddr | quote }}
   # Caddy reverse-proxy target. Consumed by the Caddyfile.
   GQ_BACKEND_HOST: {{ .Values.backend.url | quote }}
   # Runtime UI settings, rendered into env.js at container startup.

--- a/charts/goquery-ui/values.yaml
+++ b/charts/goquery-ui/values.yaml
@@ -33,6 +33,12 @@ backend:
 # Runtime UI configuration (injected into env.js at container startup)
 # ----------------------------------------------------------------------------
 config:
+  # -- Caddy bind address (host:port) inside the pod. The image defaults to
+  # loopback (127.0.0.1:5137) for safety, so the chart binds all interfaces
+  # explicitly: the kubelet probes and the Service reach the pod by its IP, so
+  # loopback would break them. Network exposure is governed by the Service /
+  # NetworkPolicy / gateway, not this address.
+  listenAddr: ":5137"
   # -- URL the *browser* uses to reach the API. Leave empty to route through
   # the Caddy same-origin reverse proxy (recommended; preserves the CSP).
   apiBaseUrl: ""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,12 @@ services:
   # from environment variables — no sidecar or init container needed.
   #
   # Environment variables:
+  #   GQ_LISTEN_ADDR       - Caddy bind address. network_mode: host means the
+  #                          container shares the host's interfaces, so this
+  #                          defaults to 127.0.0.1:5137 (loopback only). To reach
+  #                          the UI from other hosts, set it to :5137 (all
+  #                          interfaces) and put it behind a reverse proxy /
+  #                          firewall, or bind a specific trusted interface.
   #   GQ_BACKEND_HOST      - backend API address for Caddy's reverse proxy
   #                          (default: http://127.0.0.1:8145)
   #   GQ_API_BASE_URL      - URL the *browser* uses to reach the API.
@@ -67,6 +73,7 @@ services:
       - frontend_data:/data
       - frontend_config:/config
     environment:
+      GQ_LISTEN_ADDR: ${GQ_LISTEN_ADDR:-127.0.0.1:5137}
       GQ_BACKEND_HOST: ${GQ_BACKEND_HOST:-http://127.0.0.1:8145}
       GQ_API_BASE_URL: ${GQ_API_BASE_URL:-}
       HOST_RESOLVER_TYPES: ${HOST_RESOLVER_TYPES:-string}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,8 +49,11 @@ services:
   #                          the UI from other hosts, set it to :5137 (all
   #                          interfaces) and put it behind a reverse proxy /
   #                          firewall, or bind a specific trusted interface.
-  #   GQ_BACKEND_HOST      - backend API address for Caddy's reverse proxy
-  #                          (default: http://127.0.0.1:8145)
+  #   GQ_BACKEND_HOST      - address of the global-query API that Caddy forwards
+  #                          the UI's /_query and /-/ requests to. This is Caddy's
+  #                          own in-container forwarding, not any external reverse
+  #                          proxy (e.g. nginx) you may run in front of the UI.
+  #                          Match it to the query service's SERVER_ADDR above.
   #   GQ_API_BASE_URL      - URL the *browser* uses to reach the API.
   #                          Leave empty (default) to route via the Caddy proxy.
   #   HOST_RESOLVER_TYPES  - comma-separated resolver types shown in the UI (default: string)
@@ -74,7 +77,7 @@ services:
       - frontend_config:/config
     environment:
       GQ_LISTEN_ADDR: ${GQ_LISTEN_ADDR:-127.0.0.1:5137}
-      GQ_BACKEND_HOST: ${GQ_BACKEND_HOST:-http://127.0.0.1:8145}
+      GQ_BACKEND_HOST: ${GQ_BACKEND_HOST:-http://127.0.0.1:8146}
       GQ_API_BASE_URL: ${GQ_API_BASE_URL:-}
       HOST_RESOLVER_TYPES: ${HOST_RESOLVER_TYPES:-string}
       SSE_ON_LOAD: ${SSE_ON_LOAD:-true}

--- a/frontend/goquery-ui/Dockerfile
+++ b/frontend/goquery-ui/Dockerfile
@@ -59,11 +59,16 @@ USER caddy
 
 EXPOSE 5137
 
-# Runtime env vars with defaults (override in K8s Deployment / docker-compose)
+# Runtime env vars with defaults (override in K8s Deployment / docker-compose).
+# GQ_LISTEN_ADDR controls Caddy's bind address; it defaults to 127.0.0.1:5137
+# (loopback, secure by default). Bridged containers and Kubernetes must bind all
+# interfaces — set GQ_LISTEN_ADDR=:5137 (the Helm chart and bridge compose do
+# this explicitly). See #479.
 ENV GQ_API_BASE_URL="" \
     HOST_RESOLVER_TYPES="string" \
     SSE_ON_LOAD="true" \
-    GQ_BACKEND_HOST=""
+    GQ_BACKEND_HOST="" \
+    GQ_LISTEN_ADDR="127.0.0.1:5137"
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/frontend/goquery-ui/README.md
+++ b/frontend/goquery-ui/README.md
@@ -58,6 +58,24 @@ make docker-up    # run the hardened image (docker compose up --build)
 make docker-build # build Caddy image locally
 ```
 
+### Listen address & exposure
+
+Caddy's bind address is set by `GQ_LISTEN_ADDR` (host:port). The image is
+**secure by default**: it binds `127.0.0.1:5137` (loopback only), so the UI is
+not exposed on any external interface unless you opt in.
+
+- **`network_mode: host`**: the default `127.0.0.1:5137` keeps the UI local to
+  the host. To reach it from other machines, set `GQ_LISTEN_ADDR=:5137` (all
+  interfaces) or a specific trusted interface, and front it with a reverse
+  proxy / firewall. The provided host-network `docker-compose.yaml` makes the
+  loopback default explicit.
+- **Bridged containers / Kubernetes**: the container needs to bind all
+  interfaces so published ports (`docker run -p`) and the kubelet probes /
+  Service can reach it by IP — loopback would break them. These set
+  `GQ_LISTEN_ADDR=:5137` explicitly: the Helm chart via `config.listenAddr`, the
+  bridge `docker-compose.yml` by pinning it. Exposure is still governed by the
+  published ports / Service / Ingress, not the in-container bind address.
+
 ## Using the UI
 
 - Time range: quick presets (5m…30d) or set exact From/To.

--- a/frontend/goquery-ui/deploy/Caddyfile
+++ b/frontend/goquery-ui/deploy/Caddyfile
@@ -4,7 +4,14 @@
 	admin off
 }
 
-:5137 {
+# Listen address, configurable via GQ_LISTEN_ADDR (host:port). Defaults to
+# 127.0.0.1:5137 — loopback only — so the UI is not exposed on any external
+# interface out of the box. Bridged containers and Kubernetes must bind all
+# interfaces (published ports / the kubelet probes and Service reach the
+# container by IP, not loopback): they set GQ_LISTEN_ADDR=:5137 explicitly — the
+# Helm chart via config.listenAddr, the bridge docker-compose by pinning it.
+# See #479.
+{$GQ_LISTEN_ADDR:127.0.0.1:5137} {
 	root * /opt/app/www
 	encode zstd gzip
 

--- a/frontend/goquery-ui/docker-compose.yml
+++ b/frontend/goquery-ui/docker-compose.yml
@@ -16,6 +16,10 @@ services:
       - "8080:5137"
     # Runtime config — override via an optional .env next to this file.
     environment:
+      # Bridge networking with published ports: Caddy must bind all interfaces
+      # inside the container so Docker's port mapping (8080 -> 5137) can reach
+      # it. Exposure is controlled by the host-side port publishing, not here.
+      GQ_LISTEN_ADDR: "${GQ_LISTEN_ADDR:-:5137}"
       GQ_API_BASE_URL: "${GQ_API_BASE_URL:-}"
       HOST_RESOLVER_TYPES: "${HOST_RESOLVER_TYPES:-string}"
       SSE_ON_LOAD: "${SSE_ON_LOAD:-true}"


### PR DESCRIPTION
By default Caddy bound :5137 on all interfaces with no way to change it. In
network_mode: host that exposes the UI on every host interface, which is
rarely intended.

Add GQ_LISTEN_ADDR (host:port) and make the image secure by default:

- Caddyfile: site address from {$GQ_LISTEN_ADDR:127.0.0.1:5137}.
- Dockerfile: default 127.0.0.1:5137 (loopback) — the UI is not exposed on any
  external interface out of the box.
- Bridged containers and Kubernetes must bind all interfaces (published ports /
  the kubelet probes and Service reach the container by IP, not loopback), so
  they set GQ_LISTEN_ADDR=:5137 explicitly:
  - Helm chart: config.listenAddr (default ":5137") wired through the ConfigMap.
  - goquery-ui/docker-compose.yml (bridge): pins ":5137".
- docker-compose.yaml (host network): makes the loopback default explicit and
  documents how to expose the UI deliberately.
- README: document the secure default and the bind-address knob.

Closes #479

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>